### PR TITLE
Move schedule name into Schedule

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -48,6 +48,11 @@ path = "benches/bevy_reflect/struct.rs"
 harness = false
 
 [[bench]]
+name = "parse_reflect_path"
+path = "benches/bevy_reflect/path.rs"
+harness = false
+
+[[bench]]
 name = "iter"
 path = "benches/bevy_tasks/iter.rs"
 harness = false

--- a/benches/benches/bevy_ecs/components/archetype_updates.rs
+++ b/benches/benches/bevy_ecs/components/archetype_updates.rs
@@ -7,7 +7,7 @@ struct A<const N: u16>(f32);
 fn setup(system_count: usize) -> (World, Schedule) {
     let mut world = World::new();
     fn empty() {}
-    let mut schedule = Schedule::new();
+    let mut schedule = Schedule::default();
     for _ in 0..system_count {
         schedule.add_systems(empty);
     }

--- a/benches/benches/bevy_ecs/empty_archetypes.rs
+++ b/benches/benches/bevy_ecs/empty_archetypes.rs
@@ -77,7 +77,7 @@ fn par_for_each(
 
 fn setup(parallel: bool, setup: impl FnOnce(&mut Schedule)) -> (World, Schedule) {
     let mut world = World::new();
-    let mut schedule = Schedule::new();
+    let mut schedule = Schedule::default();
     if parallel {
         world.insert_resource(ComputeTaskPool(TaskPool::default()));
     }

--- a/benches/benches/bevy_ecs/scheduling/run_condition.rs
+++ b/benches/benches/bevy_ecs/scheduling/run_condition.rs
@@ -18,7 +18,7 @@ pub fn run_condition_yes(criterion: &mut Criterion) {
     group.measurement_time(std::time::Duration::from_secs(3));
     fn empty() {}
     for amount in 0..21 {
-        let mut schedule = Schedule::new();
+        let mut schedule = Schedule::default();
         schedule.add_systems(empty.run_if(yes));
         for _ in 0..amount {
             schedule.add_systems((empty, empty, empty, empty, empty).distributive_run_if(yes));
@@ -41,7 +41,7 @@ pub fn run_condition_no(criterion: &mut Criterion) {
     group.measurement_time(std::time::Duration::from_secs(3));
     fn empty() {}
     for amount in 0..21 {
-        let mut schedule = Schedule::new();
+        let mut schedule = Schedule::default();
         schedule.add_systems(empty.run_if(no));
         for _ in 0..amount {
             schedule.add_systems((empty, empty, empty, empty, empty).distributive_run_if(no));
@@ -71,7 +71,7 @@ pub fn run_condition_yes_with_query(criterion: &mut Criterion) {
         query.single().0
     }
     for amount in 0..21 {
-        let mut schedule = Schedule::new();
+        let mut schedule = Schedule::default();
         schedule.add_systems(empty.run_if(yes_with_query));
         for _ in 0..amount {
             schedule.add_systems(
@@ -100,7 +100,7 @@ pub fn run_condition_yes_with_resource(criterion: &mut Criterion) {
         res.0
     }
     for amount in 0..21 {
-        let mut schedule = Schedule::new();
+        let mut schedule = Schedule::default();
         schedule.add_systems(empty.run_if(yes_with_resource));
         for _ in 0..amount {
             schedule.add_systems(

--- a/benches/benches/bevy_ecs/scheduling/running_systems.rs
+++ b/benches/benches/bevy_ecs/scheduling/running_systems.rs
@@ -21,7 +21,7 @@ pub fn empty_systems(criterion: &mut Criterion) {
     group.measurement_time(std::time::Duration::from_secs(3));
     fn empty() {}
     for amount in 0..5 {
-        let mut schedule = Schedule::new();
+        let mut schedule = Schedule::default();
         for _ in 0..amount {
             schedule.add_systems(empty);
         }
@@ -33,7 +33,7 @@ pub fn empty_systems(criterion: &mut Criterion) {
         });
     }
     for amount in 1..21 {
-        let mut schedule = Schedule::new();
+        let mut schedule = Schedule::default();
         for _ in 0..amount {
             schedule.add_systems((empty, empty, empty, empty, empty));
         }
@@ -73,7 +73,7 @@ pub fn busy_systems(criterion: &mut Criterion) {
         world.spawn_batch((0..ENTITY_BUNCH).map(|_| (A(0.0), B(0.0), C(0.0), D(0.0))));
         world.spawn_batch((0..ENTITY_BUNCH).map(|_| (A(0.0), B(0.0), C(0.0), E(0.0))));
         for system_amount in 0..5 {
-            let mut schedule = Schedule::new();
+            let mut schedule = Schedule::default();
             schedule.add_systems((ab, cd, ce));
             for _ in 0..system_amount {
                 schedule.add_systems((ab, cd, ce));
@@ -124,7 +124,7 @@ pub fn contrived(criterion: &mut Criterion) {
         world.spawn_batch((0..ENTITY_BUNCH).map(|_| (A(0.0), B(0.0))));
         world.spawn_batch((0..ENTITY_BUNCH).map(|_| (C(0.0), D(0.0))));
         for system_amount in 0..5 {
-            let mut schedule = Schedule::new();
+            let mut schedule = Schedule::default();
             schedule.add_systems((s_0, s_1, s_2));
             for _ in 0..system_amount {
                 schedule.add_systems((s_0, s_1, s_2));

--- a/benches/benches/bevy_ecs/scheduling/schedule.rs
+++ b/benches/benches/bevy_ecs/scheduling/schedule.rs
@@ -46,7 +46,7 @@ pub fn schedule(c: &mut Criterion) {
 
         world.spawn_batch((0..10000).map(|_| (A(0.0), B(0.0), C(0.0), E(0.0))));
 
-        let mut schedule = Schedule::new();
+        let mut schedule = Schedule::default();
         schedule.add_systems((ab, cd, ce));
         schedule.run(&mut world);
 

--- a/benches/benches/bevy_math/bezier.rs
+++ b/benches/benches/bevy_math/bezier.rs
@@ -14,7 +14,7 @@ fn easing(c: &mut Criterion) {
 }
 
 fn cubic_2d(c: &mut Criterion) {
-    let bezier = Bezier::new([[
+    let bezier = CubicBezier::new([[
         vec2(0.0, 0.0),
         vec2(0.0, 1.0),
         vec2(1.0, 0.0),
@@ -27,7 +27,7 @@ fn cubic_2d(c: &mut Criterion) {
 }
 
 fn cubic(c: &mut Criterion) {
-    let bezier = Bezier::new([[
+    let bezier = CubicBezier::new([[
         vec3a(0.0, 0.0, 0.0),
         vec3a(0.0, 1.0, 0.0),
         vec3a(1.0, 0.0, 0.0),
@@ -40,7 +40,7 @@ fn cubic(c: &mut Criterion) {
 }
 
 fn cubic_vec3(c: &mut Criterion) {
-    let bezier = Bezier::new([[
+    let bezier = CubicBezier::new([[
         vec3(0.0, 0.0, 0.0),
         vec3(0.0, 1.0, 0.0),
         vec3(1.0, 0.0, 0.0),
@@ -53,7 +53,7 @@ fn cubic_vec3(c: &mut Criterion) {
 }
 
 fn build_pos_cubic(c: &mut Criterion) {
-    let bezier = Bezier::new([[
+    let bezier = CubicBezier::new([[
         vec3a(0.0, 0.0, 0.0),
         vec3a(0.0, 1.0, 0.0),
         vec3a(1.0, 0.0, 0.0),
@@ -66,7 +66,7 @@ fn build_pos_cubic(c: &mut Criterion) {
 }
 
 fn build_accel_cubic(c: &mut Criterion) {
-    let bezier = Bezier::new([[
+    let bezier = CubicBezier::new([[
         vec3a(0.0, 0.0, 0.0),
         vec3a(0.0, 1.0, 0.0),
         vec3a(1.0, 0.0, 0.0),

--- a/benches/benches/bevy_reflect/path.rs
+++ b/benches/benches/bevy_reflect/path.rs
@@ -1,0 +1,94 @@
+use std::{fmt::Write, str, time::Duration};
+
+use bevy_reflect::ParsedPath;
+use criterion::{
+    black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput,
+};
+use rand::{distributions::Uniform, Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+criterion_group!(benches, parse_reflect_path);
+criterion_main!(benches);
+
+const WARM_UP_TIME: Duration = Duration::from_millis(500);
+const MEASUREMENT_TIME: Duration = Duration::from_secs(2);
+const SAMPLE_SIZE: usize = 500;
+const NOISE_THRESHOLD: f64 = 0.03;
+const SIZES: [usize; 6] = [100, 3160, 1000, 3_162, 10_000, 24_000];
+
+fn deterministic_rand() -> ChaCha8Rng {
+    ChaCha8Rng::seed_from_u64(42)
+}
+fn random_ident(rng: &mut ChaCha8Rng, f: &mut dyn Write) {
+    let between = Uniform::try_from(b'a'..=b'z').unwrap();
+    let ident_size = rng.gen_range(1..128);
+    let ident: Vec<u8> = rng.sample_iter(between).take(ident_size).collect();
+    let ident = str::from_utf8(&ident).unwrap();
+    let _ = write!(f, "{ident}");
+}
+
+fn random_index(rng: &mut ChaCha8Rng, f: &mut dyn Write) {
+    let index = rng.gen_range(1..128);
+    let _ = write!(f, "{index}");
+}
+
+fn write_random_access(rng: &mut ChaCha8Rng, f: &mut dyn Write) {
+    match rng.gen_range(0..4) {
+        0 => {
+            // Access::Field
+            f.write_char('.').unwrap();
+            random_ident(rng, f);
+        }
+        1 => {
+            // Access::FieldIndex
+            f.write_char('#').unwrap();
+            random_index(rng, f);
+        }
+        2 => {
+            // Access::Index
+            f.write_char('[').unwrap();
+            random_index(rng, f);
+            f.write_char(']').unwrap();
+        }
+        3 => {
+            // Access::TupleIndex
+            f.write_char('.').unwrap();
+            random_index(rng, f);
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn mk_paths(size: usize) -> impl FnMut() -> String {
+    let mut rng = deterministic_rand();
+    move || {
+        let mut ret = String::new();
+        (0..size).for_each(|_| write_random_access(&mut rng, &mut ret));
+        ret
+    }
+}
+
+fn parse_reflect_path(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("parse_reflect_path");
+    group.warm_up_time(WARM_UP_TIME);
+    group.measurement_time(MEASUREMENT_TIME);
+    group.sample_size(SAMPLE_SIZE);
+    group.noise_threshold(NOISE_THRESHOLD);
+    let group = &mut group;
+
+    for size in SIZES {
+        group.throughput(Throughput::Elements(size as u64));
+        group.bench_with_input(
+            BenchmarkId::new("parse_reflect_path", size),
+            &size,
+            |bencher, &size| {
+                let mut mk_paths = mk_paths(size);
+                bencher.iter_batched(
+                    || mk_paths(),
+                    |path| assert!(ParsedPath::parse(black_box(&path)).is_ok()),
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+}

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -102,12 +102,6 @@ impl AnimationClip {
         self.duration
     }
 
-    /// The bone ids mapped by their [`EntityPath`].
-    #[inline]
-    pub fn paths(&self) -> &HashMap<EntityPath, usize> {
-        &self.paths
-    }
-
     /// Add a [`VariableCurve`] to an [`EntityPath`].
     pub fn add_curve_to_path(&mut self, path: EntityPath, curve: VariableCurve) {
         // Update the duration of the animation by this curve duration if it's longer
@@ -129,24 +123,93 @@ impl AnimationClip {
     }
 }
 
+/// Repetition behavior of an animation.
+#[derive(Reflect, Copy, Clone, Default)]
+pub enum RepeatAnimation {
+    /// The animation will finish after running once.
+    #[default]
+    Never,
+    /// The animation will finish after running "n" times.
+    Count(u32),
+    /// The animation will never finish.
+    Forever,
+}
+
 #[derive(Reflect)]
 struct PlayingAnimation {
-    repeat: bool,
+    repeat: RepeatAnimation,
     speed: f32,
+    /// Total time the animation has been played.
+    ///
+    /// Note: Time does not increase when the animation is paused or after it has completed.
     elapsed: f32,
+    /// The timestamp inside of the animation clip.
+    ///
+    /// Note: This will always be in the range [0.0, animation clip duration]
+    seek_time: f32,
     animation_clip: Handle<AnimationClip>,
     path_cache: Vec<Vec<Option<Entity>>>,
+    /// Number of times the animation has completed.
+    /// If the animation is playing in reverse, this increments when the animation passes the start.
+    completions: u32,
 }
 
 impl Default for PlayingAnimation {
     fn default() -> Self {
         Self {
-            repeat: false,
+            repeat: RepeatAnimation::default(),
             speed: 1.0,
             elapsed: 0.0,
+            seek_time: 0.0,
             animation_clip: Default::default(),
             path_cache: Vec::new(),
+            completions: 0,
         }
+    }
+}
+
+impl PlayingAnimation {
+    /// Check if the animation has finished, based on its repetition behavior and the number of times it has repeated.
+    ///
+    /// Note: An animation with `RepeatAnimation::Forever` will never finish.
+    #[inline]
+    pub fn is_finished(&self) -> bool {
+        match self.repeat {
+            RepeatAnimation::Forever => false,
+            RepeatAnimation::Never => self.completions >= 1,
+            RepeatAnimation::Count(n) => self.completions >= n,
+        }
+    }
+
+    /// Update the animation given the delta time and the duration of the clip being played.
+    #[inline]
+    fn update(&mut self, delta: f32, clip_duration: f32) {
+        if self.is_finished() {
+            return;
+        }
+
+        self.elapsed += delta;
+        self.seek_time += delta * self.speed;
+
+        if (self.seek_time > clip_duration && self.speed > 0.0)
+            || (self.seek_time < 0.0 && self.speed < 0.0)
+        {
+            self.completions += 1;
+        }
+
+        if self.seek_time >= clip_duration {
+            self.seek_time %= clip_duration;
+        }
+        if self.seek_time < 0.0 {
+            self.seek_time += clip_duration;
+        }
+    }
+
+    /// Reset back to the initial state as if no time has elapsed.
+    fn replay(&mut self) {
+        self.completions = 0;
+        self.elapsed = 0.0;
+        self.seek_time = 0.0;
     }
 }
 
@@ -222,7 +285,7 @@ impl AnimationPlayer {
     /// If `transition_duration` is set, this will use a linear blending
     /// between the previous and the new animation to make a smooth transition
     pub fn play(&mut self, handle: Handle<AnimationClip>) -> &mut Self {
-        if self.animation.animation_clip != handle || self.is_paused() {
+        if !self.is_playing_clip(&handle) || self.is_paused() {
             self.start(handle);
         }
         self
@@ -235,22 +298,54 @@ impl AnimationPlayer {
         handle: Handle<AnimationClip>,
         transition_duration: Duration,
     ) -> &mut Self {
-        if self.animation.animation_clip != handle || self.is_paused() {
+        if !self.is_playing_clip(&handle) || self.is_paused() {
             self.start_with_transition(handle, transition_duration);
         }
         self
     }
 
-    /// Set the animation to repeat
+    /// Handle to the animation clip being played.
+    pub fn animation_clip(&self) -> &Handle<AnimationClip> {
+        &self.animation.animation_clip
+    }
+
+    /// Check if the given animation clip is being played.
+    pub fn is_playing_clip(&self, handle: &Handle<AnimationClip>) -> bool {
+        self.animation_clip() == handle
+    }
+
+    /// Check if the playing animation has finished, according to the repetition behavior.
+    pub fn is_finished(&self) -> bool {
+        self.animation.is_finished()
+    }
+
+    /// Sets repeat to [`RepeatAnimation::Forever`].
+    ///
+    /// See also [`Self::set_repeat`].
     pub fn repeat(&mut self) -> &mut Self {
-        self.animation.repeat = true;
+        self.animation.repeat = RepeatAnimation::Forever;
         self
     }
 
-    /// Stop the animation from repeating
-    pub fn stop_repeating(&mut self) -> &mut Self {
-        self.animation.repeat = false;
+    /// Set the repetition behaviour of the animation.
+    pub fn set_repeat(&mut self, repeat: RepeatAnimation) -> &mut Self {
+        self.animation.repeat = repeat;
         self
+    }
+
+    /// Repetition behavior of the animation.
+    pub fn repeat_mode(&self) -> RepeatAnimation {
+        self.animation.repeat
+    }
+
+    /// Number of times the animation has completed.
+    pub fn completions(&self) -> u32 {
+        self.animation.completions
+    }
+
+    /// Check if the animation is playing in reverse.
+    pub fn is_playback_reversed(&self) -> bool {
+        self.animation.speed < 0.0
     }
 
     /// Pause the animation
@@ -284,10 +379,20 @@ impl AnimationPlayer {
         self.animation.elapsed
     }
 
-    /// Seek to a specific time in the animation
-    pub fn set_elapsed(&mut self, elapsed: f32) -> &mut Self {
-        self.animation.elapsed = elapsed;
+    /// Seek time inside of the animation. Always within the range [0.0, clip duration].
+    pub fn seek_time(&self) -> f32 {
+        self.animation.seek_time
+    }
+
+    /// Seek to a specific time in the animation.
+    pub fn seek_to(&mut self, seek_time: f32) -> &mut Self {
+        self.animation.seek_time = seek_time;
         self
+    }
+
+    /// Reset the animation to its initial state, as if no time has elapsed.
+    pub fn replay(&mut self) {
+        self.animation.replay();
     }
 }
 
@@ -489,16 +594,12 @@ fn apply_animation(
     children: &Query<&Children>,
 ) {
     if let Some(animation_clip) = animations.get(&animation.animation_clip) {
-        if !paused {
-            animation.elapsed += time.delta_seconds() * animation.speed;
-        }
-        let mut elapsed = animation.elapsed;
-        if animation.repeat {
-            elapsed %= animation_clip.duration;
-        }
-        if elapsed < 0.0 {
-            elapsed += animation_clip.duration;
-        }
+        // We don't return early because seek_to() may have been called on the animation player.
+        animation.update(
+            if paused { 0.0 } else { time.delta_seconds() },
+            animation_clip.duration,
+        );
+
         if animation.path_cache.len() != animation_clip.paths.len() {
             animation.path_cache = vec![Vec::new(); animation_clip.paths.len()];
         }
@@ -556,7 +657,7 @@ fn apply_animation(
                 // PERF: finding the current keyframe can be optimised
                 let step_start = match curve
                     .keyframe_timestamps
-                    .binary_search_by(|probe| probe.partial_cmp(&elapsed).unwrap())
+                    .binary_search_by(|probe| probe.partial_cmp(&animation.seek_time).unwrap())
                 {
                     Ok(n) if n >= curve.keyframe_timestamps.len() - 1 => continue, // this curve is finished
                     Ok(i) => i,
@@ -566,7 +667,7 @@ fn apply_animation(
                 };
                 let ts_start = curve.keyframe_timestamps[step_start];
                 let ts_end = curve.keyframe_timestamps[step_start + 1];
-                let lerp = (elapsed - ts_start) / (ts_end - ts_start);
+                let lerp = (animation.seek_time - ts_start) / (ts_end - ts_start);
 
                 // Apply the keyframe
                 match &curve.keyframes {
@@ -620,7 +721,6 @@ impl Plugin for AnimationPlugin {
         app.add_asset::<AnimationClip>()
             .register_asset_reflect::<AnimationClip>()
             .register_type::<AnimationPlayer>()
-            .register_type::<PlayingAnimation>()
             .add_systems(
                 PostUpdate,
                 animation_player.before(TransformSystem::TransformPropagate),

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -341,9 +341,13 @@ fn verify_no_ancestor_player(
     player_parent: Option<&Parent>,
     parents: &Query<(Option<With<AnimationPlayer>>, Option<&Parent>)>,
 ) -> bool {
-    let Some(mut current) = player_parent.map(Parent::get) else { return true };
+    let Some(mut current) = player_parent.map(Parent::get) else {
+        return true;
+    };
     loop {
-        let Ok((maybe_player, parent)) = parents.get(current) else { return true };
+        let Ok((maybe_player, parent)) = parents.get(current) else {
+            return true;
+        };
         if maybe_player.is_some() {
             return false;
         }
@@ -506,7 +510,9 @@ fn apply_animation(
         for (path, bone_id) in &animation_clip.paths {
             let cached_path = &mut animation.path_cache[*bone_id];
             let curves = animation_clip.get_curves(*bone_id).unwrap();
-            let Some(target) = entity_from_path(root, path, children, names, cached_path) else { continue };
+            let Some(target) = entity_from_path(root, path, children, names, cached_path) else {
+                continue;
+            };
             // SAFETY: The verify_no_ancestor_player check above ensures that two animation players cannot alias
             // any of their descendant Transforms.
             //
@@ -519,7 +525,9 @@ fn apply_animation(
             // This means only the AnimationPlayers closest to the root of the hierarchy will be able
             // to run their animation. Any players in the children or descendants will log a warning
             // and do nothing.
-            let Ok(mut transform) = (unsafe { transforms.get_unchecked(target) }) else { continue };
+            let Ok(mut transform) = (unsafe { transforms.get_unchecked(target) }) else {
+                continue;
+            };
             let mut morphs = unsafe { morphs.get_unchecked(target) };
             for curve in curves {
                 // Some curves have only one keyframe used to set a transform

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -393,6 +393,7 @@ impl App {
     }
 
     /// Configures a system set in the default schedule, adding the set if it does not exist.
+    #[track_caller]
     pub fn configure_set(
         &mut self,
         schedule: impl ScheduleLabel,
@@ -410,6 +411,7 @@ impl App {
     }
 
     /// Configures a collection of system sets in the default schedule, adding any sets that do not exist.
+    #[track_caller]
     pub fn configure_sets(
         &mut self,
         schedule: impl ScheduleLabel,

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -384,9 +384,9 @@ impl App {
         if let Some(schedule) = schedules.get_mut(&schedule) {
             schedule.add_systems(systems);
         } else {
-            let mut new_schedule = Schedule::new();
+            let mut new_schedule = Schedule::new(schedule);
             new_schedule.add_systems(systems);
-            schedules.insert(schedule, new_schedule);
+            schedules.insert(new_schedule);
         }
 
         self
@@ -403,9 +403,9 @@ impl App {
         if let Some(schedule) = schedules.get_mut(&schedule) {
             schedule.configure_set(set);
         } else {
-            let mut new_schedule = Schedule::new();
+            let mut new_schedule = Schedule::new(schedule);
             new_schedule.configure_set(set);
-            schedules.insert(schedule, new_schedule);
+            schedules.insert(new_schedule);
         }
         self
     }
@@ -421,9 +421,9 @@ impl App {
         if let Some(schedule) = schedules.get_mut(&schedule) {
             schedule.configure_sets(sets);
         } else {
-            let mut new_schedule = Schedule::new();
+            let mut new_schedule = Schedule::new(schedule);
             new_schedule.configure_sets(sets);
-            schedules.insert(schedule, new_schedule);
+            schedules.insert(new_schedule);
         }
         self
     }
@@ -798,9 +798,9 @@ impl App {
     /// # Warning
     /// This method will overwrite any existing schedule at that label.
     /// To avoid this behavior, use the `init_schedule` method instead.
-    pub fn add_schedule(&mut self, label: impl ScheduleLabel, schedule: Schedule) -> &mut Self {
+    pub fn add_schedule(&mut self, schedule: Schedule) -> &mut Self {
         let mut schedules = self.world.resource_mut::<Schedules>();
-        schedules.insert(label, schedule);
+        schedules.insert(schedule);
 
         self
     }
@@ -811,7 +811,7 @@ impl App {
     pub fn init_schedule(&mut self, label: impl ScheduleLabel) -> &mut Self {
         let mut schedules = self.world.resource_mut::<Schedules>();
         if !schedules.contains(&label) {
-            schedules.insert(label, Schedule::new());
+            schedules.insert(Schedule::new(label));
         }
         self
     }
@@ -841,7 +841,7 @@ impl App {
         let mut schedules = self.world.resource_mut::<Schedules>();
 
         if schedules.get(&label).is_none() {
-            schedules.insert(label.dyn_clone(), Schedule::new());
+            schedules.insert(Schedule::new(label.dyn_clone()));
         }
 
         let schedule = schedules.get_mut(&label).unwrap();

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -5,7 +5,7 @@ use bevy_ecs::{
     schedule::{
         apply_state_transition, common_conditions::run_once as run_once_condition,
         run_enter_schedule, BoxedScheduleLabel, IntoSystemConfigs, IntoSystemSetConfigs,
-        ScheduleLabel,
+        ScheduleBuildSettings, ScheduleLabel,
     },
 };
 use bevy_utils::{tracing::debug, HashMap, HashSet};
@@ -848,6 +848,17 @@ impl App {
         // Call the function f, passing in the schedule retrieved
         f(schedule);
 
+        self
+    }
+
+    /// Applies the provided [`ScheduleBuildSettings`] to all schedules.
+    pub fn configure_schedules(
+        &mut self,
+        schedule_build_settings: ScheduleBuildSettings,
+    ) -> &mut Self {
+        self.world
+            .resource_mut::<Schedules>()
+            .configure_schedules(schedule_build_settings);
         self
     }
 }

--- a/crates/bevy_app/src/main_schedule.rs
+++ b/crates/bevy_app/src/main_schedule.rs
@@ -161,13 +161,13 @@ pub struct MainSchedulePlugin;
 impl Plugin for MainSchedulePlugin {
     fn build(&self, app: &mut App) {
         // simple "facilitator" schedules benefit from simpler single threaded scheduling
-        let mut main_schedule = Schedule::new();
+        let mut main_schedule = Schedule::new(Main);
         main_schedule.set_executor_kind(ExecutorKind::SingleThreaded);
-        let mut fixed_update_loop_schedule = Schedule::new();
+        let mut fixed_update_loop_schedule = Schedule::new(RunFixedUpdateLoop);
         fixed_update_loop_schedule.set_executor_kind(ExecutorKind::SingleThreaded);
 
-        app.add_schedule(Main, main_schedule)
-            .add_schedule(RunFixedUpdateLoop, fixed_update_loop_schedule)
+        app.add_schedule(main_schedule)
+            .add_schedule(fixed_update_loop_schedule)
             .init_resource::<MainScheduleOrder>()
             .add_systems(Main, Main::run_main);
     }

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -89,15 +89,6 @@ impl Plugin for ScheduleRunnerPlugin {
                           -> Result<Option<Duration>, AppExit> {
                         let start_time = Instant::now();
 
-                        if let Some(app_exit_events) =
-                            app.world.get_resource_mut::<Events<AppExit>>()
-                        {
-                            if let Some(exit) = app_exit_event_reader.iter(&app_exit_events).last()
-                            {
-                                return Err(exit.clone());
-                            }
-                        }
-
                         app.update();
 
                         if let Some(app_exit_events) =

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -790,7 +790,8 @@ mod test {
         let asset_server = setup(".");
         asset_server.add_loader(FakePngLoader);
 
-        let Ok(MaybeAssetLoader::Ready(t)) = asset_server.get_path_asset_loader("test.png", true) else {
+        let Ok(MaybeAssetLoader::Ready(t)) = asset_server.get_path_asset_loader("test.png", true)
+        else {
             panic!();
         };
 
@@ -802,7 +803,8 @@ mod test {
         let asset_server = setup(".");
         asset_server.add_loader(FakePngLoader);
 
-        let Ok(MaybeAssetLoader::Ready(t)) = asset_server.get_path_asset_loader("test.PNG", true) else {
+        let Ok(MaybeAssetLoader::Ready(t)) = asset_server.get_path_asset_loader("test.PNG", true)
+        else {
             panic!();
         };
         assert_eq!(t.extensions()[0], "png");
@@ -855,7 +857,9 @@ mod test {
         let asset_server = setup(".");
         asset_server.add_loader(FakePngLoader);
 
-        let Ok(MaybeAssetLoader::Ready(t)) = asset_server.get_path_asset_loader("test-v1.2.3.png", true) else {
+        let Ok(MaybeAssetLoader::Ready(t)) =
+            asset_server.get_path_asset_loader("test-v1.2.3.png", true)
+        else {
             panic!();
         };
         assert_eq!(t.extensions()[0], "png");
@@ -866,7 +870,9 @@ mod test {
         let asset_server = setup(".");
         asset_server.add_loader(FakeMultipleDotLoader);
 
-        let Ok(MaybeAssetLoader::Ready(t)) = asset_server.get_path_asset_loader("test.test.png", true) else {
+        let Ok(MaybeAssetLoader::Ready(t)) =
+            asset_server.get_path_asset_loader("test.test.png", true)
+        else {
             panic!();
         };
         assert_eq!(t.extensions()[0], "test.png");

--- a/crates/bevy_asset/src/io/file_asset_io.rs
+++ b/crates/bevy_asset/src/io/file_asset_io.rs
@@ -114,10 +114,11 @@ impl AssetIo for FileAssetIo {
         path: &Path,
     ) -> Result<Box<dyn Iterator<Item = PathBuf>>, AssetIoError> {
         let root_path = self.root_path.to_owned();
-        Ok(Box::new(fs::read_dir(root_path.join(path))?.map(
+        let path = path.to_owned();
+        Ok(Box::new(fs::read_dir(root_path.join(&path))?.map(
             move |entry| {
-                let path = entry.unwrap().path();
-                path.strip_prefix(&root_path).unwrap().to_owned()
+                let file_name = entry.unwrap().file_name();
+                path.join(file_name)
             },
         )))
     }

--- a/crates/bevy_asset/src/io/file_asset_io.rs
+++ b/crates/bevy_asset/src/io/file_asset_io.rs
@@ -201,7 +201,9 @@ pub fn filesystem_watcher_system(
             } = event
             {
                 for path in &paths {
-                    let Some(set) = watcher.path_map.get(path) else {continue};
+                    let Some(set) = watcher.path_map.get(path) else {
+                        continue;
+                    };
                     for to_reload in set {
                         // When an asset is modified, note down the timestamp (overriding any previous modification events)
                         changed.insert(to_reload.to_owned(), Instant::now());

--- a/crates/bevy_audio/src/sinks.rs
+++ b/crates/bevy_audio/src/sinks.rs
@@ -15,6 +15,14 @@ pub trait AudioSinkPlayback {
     ///
     /// The value `1.0` is the "normal" volume (unfiltered input). Any value other than `1.0`
     /// will multiply each sample by this value.
+    ///
+    /// # Note on Audio Volume
+    ///
+    /// An increase of 10 decibels (dB) roughly corresponds to the perceived volume doubling in intensity.
+    /// As this function scales not the volume but the amplitude, a conversion might be necessary.
+    /// For example, to halve the perceived volume you need to decrease the volume by 10 dB.
+    /// This corresponds to 20log(x) = -10dB, solving x = 10^(-10/20) = 0.316.
+    /// Multiply the current volume by 0.316 to halve the perceived volume.
     fn set_volume(&self, volume: f32);
 
     /// Gets the speed of the sound.

--- a/crates/bevy_core_pipeline/src/blit/mod.rs
+++ b/crates/bevy_core_pipeline/src/blit/mod.rs
@@ -19,7 +19,7 @@ impl Plugin for BlitPlugin {
 
     fn finish(&self, app: &mut App) {
         let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
-            return
+            return;
         };
 
         render_app

--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -68,10 +68,10 @@ impl Plugin for BloomPlugin {
             .add_systems(
                 Render,
                 (
-                    prepare_bloom_textures.in_set(RenderSet::Prepare),
                     prepare_downsampling_pipeline.in_set(RenderSet::Prepare),
                     prepare_upsampling_pipeline.in_set(RenderSet::Prepare),
-                    queue_bloom_bind_groups.in_set(RenderSet::Queue),
+                    prepare_bloom_textures.in_set(RenderSet::PrepareResources),
+                    prepare_bloom_bind_groups.in_set(RenderSet::PrepareBindGroups),
                 ),
             )
             // Add bloom to the 3d render graph
@@ -403,7 +403,7 @@ struct BloomBindGroups {
     sampler: Sampler,
 }
 
-fn queue_bloom_bind_groups(
+fn prepare_bloom_bind_groups(
     mut commands: Commands,
     render_device: Res<RenderDevice>,
     downsampling_pipeline: Res<BloomDownsamplingPipeline>,

--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -163,7 +163,10 @@ impl ViewNode for BloomNode {
             pipeline_cache.get_render_pipeline(downsampling_pipeline_ids.main),
             pipeline_cache.get_render_pipeline(upsampling_pipeline_ids.id_main),
             pipeline_cache.get_render_pipeline(upsampling_pipeline_ids.id_final),
-        ) else { return Ok(()) };
+        )
+        else {
+            return Ok(());
+        };
 
         render_context.command_encoder().push_debug_group("bloom");
 

--- a/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/node.rs
+++ b/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/node.rs
@@ -53,10 +53,15 @@ impl Node for CASNode {
         let sharpening_pipeline = world.resource::<CASPipeline>();
         let uniforms = world.resource::<ComponentUniforms<CASUniform>>();
 
-        let Ok((target, pipeline, uniform_index)) = self.query.get_manual(world, view_entity) else { return Ok(()) };
+        let Ok((target, pipeline, uniform_index)) = self.query.get_manual(world, view_entity)
+        else {
+            return Ok(());
+        };
 
         let uniforms_id = uniforms.buffer().unwrap().id();
-        let Some(uniforms) = uniforms.binding() else { return Ok(()) };
+        let Some(uniforms) = uniforms.binding() else {
+            return Ok(());
+        };
 
         let pipeline = pipeline_cache.get_render_pipeline(pipeline.0).unwrap();
 

--- a/crates/bevy_core_pipeline/src/msaa_writeback.rs
+++ b/crates/bevy_core_pipeline/src/msaa_writeback.rs
@@ -21,7 +21,7 @@ pub struct MsaaWritebackPlugin;
 impl Plugin for MsaaWritebackPlugin {
     fn build(&self, app: &mut App) {
         let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
-            return
+            return;
         };
 
         render_app.add_systems(

--- a/crates/bevy_core_pipeline/src/msaa_writeback.rs
+++ b/crates/bevy_core_pipeline/src/msaa_writeback.rs
@@ -26,7 +26,7 @@ impl Plugin for MsaaWritebackPlugin {
 
         render_app.add_systems(
             Render,
-            queue_msaa_writeback_pipelines.in_set(RenderSet::Queue),
+            prepare_msaa_writeback_pipelines.in_set(RenderSet::Prepare),
         );
         {
             use core_2d::graph::node::*;
@@ -123,7 +123,7 @@ impl Node for MsaaWritebackNode {
 #[derive(Component)]
 pub struct MsaaWritebackBlitPipeline(CachedRenderPipelineId);
 
-fn queue_msaa_writeback_pipelines(
+fn prepare_msaa_writeback_pipelines(
     mut commands: Commands,
     pipeline_cache: Res<PipelineCache>,
     mut pipelines: ResMut<SpecializedRenderPipelines<BlitPipeline>>,

--- a/crates/bevy_core_pipeline/src/prepass/mod.rs
+++ b/crates/bevy_core_pipeline/src/prepass/mod.rs
@@ -80,18 +80,14 @@ pub struct ViewPrepassTextures {
 /// Used to render all 3D meshes with materials that have no transparency.
 pub struct Opaque3dPrepass {
     pub distance: f32,
-    // Per-object data may be bound at different dynamic offsets within a buffer. If it is, then
-    // each batch of per-object data starts at the same dynamic offset.
-    pub per_object_binding_dynamic_offset: u32,
     pub entity: Entity,
     pub pipeline_id: CachedRenderPipelineId,
     pub draw_function: DrawFunctionId,
 }
 
 impl PhaseItem for Opaque3dPrepass {
-    // NOTE: (dynamic offset, -distance)
     // NOTE: Values increase towards the camera. Front-to-back ordering for opaque means we need a descending sort.
-    type SortKey = (u32, Reverse<FloatOrd>);
+    type SortKey = Reverse<FloatOrd>;
 
     #[inline]
     fn entity(&self) -> Entity {
@@ -100,10 +96,7 @@ impl PhaseItem for Opaque3dPrepass {
 
     #[inline]
     fn sort_key(&self) -> Self::SortKey {
-        (
-            self.per_object_binding_dynamic_offset,
-            Reverse(FloatOrd(self.distance)),
-        )
+        Reverse(FloatOrd(self.distance))
     }
 
     #[inline]
@@ -114,9 +107,7 @@ impl PhaseItem for Opaque3dPrepass {
     #[inline]
     fn sort(items: &mut [Self]) {
         // Key negated to match reversed SortKey ordering
-        radsort::sort_by_key(items, |item| {
-            (item.per_object_binding_dynamic_offset, -item.distance)
-        });
+        radsort::sort_by_key(items, |item| -item.distance);
     }
 }
 
@@ -134,18 +125,14 @@ impl CachedRenderPipelinePhaseItem for Opaque3dPrepass {
 /// Used to render all meshes with a material with an alpha mask.
 pub struct AlphaMask3dPrepass {
     pub distance: f32,
-    // Per-object data may be bound at different dynamic offsets within a buffer. If it is, then
-    // each batch of per-object data starts at the same dynamic offset.
-    pub per_object_binding_dynamic_offset: u32,
     pub entity: Entity,
     pub pipeline_id: CachedRenderPipelineId,
     pub draw_function: DrawFunctionId,
 }
 
 impl PhaseItem for AlphaMask3dPrepass {
-    // NOTE: (dynamic offset, -distance)
     // NOTE: Values increase towards the camera. Front-to-back ordering for opaque means we need a descending sort.
-    type SortKey = (u32, Reverse<FloatOrd>);
+    type SortKey = Reverse<FloatOrd>;
 
     #[inline]
     fn entity(&self) -> Entity {
@@ -154,10 +141,7 @@ impl PhaseItem for AlphaMask3dPrepass {
 
     #[inline]
     fn sort_key(&self) -> Self::SortKey {
-        (
-            self.per_object_binding_dynamic_offset,
-            Reverse(FloatOrd(self.distance)),
-        )
+        Reverse(FloatOrd(self.distance))
     }
 
     #[inline]
@@ -168,9 +152,7 @@ impl PhaseItem for AlphaMask3dPrepass {
     #[inline]
     fn sort(items: &mut [Self]) {
         // Key negated to match reversed SortKey ordering
-        radsort::sort_by_key(items, |item| {
-            (item.per_object_binding_dynamic_offset, -item.distance)
-        });
+        radsort::sort_by_key(items, |item| -item.distance);
     }
 }
 

--- a/crates/bevy_core_pipeline/src/skybox/mod.rs
+++ b/crates/bevy_core_pipeline/src/skybox/mod.rs
@@ -47,7 +47,7 @@ impl Plugin for SkyboxPlugin {
                 Render,
                 (
                     prepare_skybox_pipelines.in_set(RenderSet::Prepare),
-                    queue_skybox_bind_groups.in_set(RenderSet::Queue),
+                    prepare_skybox_bind_groups.in_set(RenderSet::PrepareBindGroups),
                 ),
             );
     }
@@ -209,7 +209,7 @@ fn prepare_skybox_pipelines(
 #[derive(Component)]
 pub struct SkyboxBindGroup(pub BindGroup);
 
-fn queue_skybox_bind_groups(
+fn prepare_skybox_bind_groups(
     mut commands: Commands,
     pipeline: Res<SkyboxPipeline>,
     view_uniforms: Res<ViewUniforms>,

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -10,7 +10,7 @@ use bevy_core::FrameCount;
 use bevy_ecs::{
     prelude::{Bundle, Component, Entity},
     query::{QueryItem, With},
-    schedule::{apply_deferred, IntoSystemConfigs},
+    schedule::IntoSystemConfigs,
     system::{Commands, Query, Res, ResMut, Resource},
     world::{FromWorld, World},
 };
@@ -31,7 +31,7 @@ use bevy_render::{
     },
     renderer::{RenderContext, RenderDevice},
     texture::{BevyDefault, CachedTexture, TextureCache},
-    view::{prepare_view_uniforms, ExtractedView, Msaa, ViewTarget},
+    view::{ExtractedView, Msaa, ViewTarget},
     ExtractSchedule, MainWorld, Render, RenderApp, RenderSet,
 };
 
@@ -67,12 +67,9 @@ impl Plugin for TemporalAntiAliasPlugin {
             .add_systems(
                 Render,
                 (
-                    (prepare_taa_jitter_and_mip_bias, apply_deferred)
-                        .chain()
-                        .before(prepare_view_uniforms)
-                        .in_set(RenderSet::Prepare),
-                    prepare_taa_history_textures.in_set(RenderSet::Prepare),
+                    prepare_taa_jitter_and_mip_bias.in_set(RenderSet::ManageViews),
                     prepare_taa_pipelines.in_set(RenderSet::Prepare),
+                    prepare_taa_history_textures.in_set(RenderSet::PrepareResources),
                 ),
             )
             .add_render_graph_node::<ViewNodeRunner<TAANode>>(CORE_3D, draw_3d_graph::node::TAA)

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -57,7 +57,9 @@ impl Plugin for TemporalAntiAliasPlugin {
         app.insert_resource(Msaa::Off)
             .register_type::<TemporalAntiAliasSettings>();
 
-        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
 
         render_app
             .init_resource::<SpecializedRenderPipelines<TAAPipeline>>()
@@ -86,7 +88,9 @@ impl Plugin for TemporalAntiAliasPlugin {
     }
 
     fn finish(&self, app: &mut App) {
-        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
 
         render_app.init_resource::<TAAPipeline>();
     }
@@ -188,11 +192,7 @@ impl ViewNode for TAANode {
         ) else {
             return Ok(());
         };
-        let (
-            Some(taa_pipeline),
-            Some(prepass_motion_vectors_texture),
-            Some(prepass_depth_texture),
-        ) = (
+        let (Some(taa_pipeline), Some(prepass_motion_vectors_texture), Some(prepass_depth_texture)) = (
             pipeline_cache.get_render_pipeline(taa_pipeline_id.0),
             &prepass_textures.motion_vectors,
             &prepass_textures.depth,

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -97,7 +97,7 @@ impl Plugin for TonemappingPlugin {
                 .init_resource::<SpecializedRenderPipelines<TonemappingPipeline>>()
                 .add_systems(
                     Render,
-                    queue_view_tonemapping_pipelines.in_set(RenderSet::Queue),
+                    prepare_view_tonemapping_pipelines.in_set(RenderSet::Prepare),
                 );
         }
     }
@@ -272,7 +272,7 @@ impl FromWorld for TonemappingPipeline {
 #[derive(Component)]
 pub struct ViewTonemappingPipeline(CachedRenderPipelineId);
 
-pub fn queue_view_tonemapping_pipelines(
+pub fn prepare_view_tonemapping_pipelines(
     mut commands: Commands,
     pipeline_cache: Res<PipelineCache>,
     mut pipelines: ResMut<SpecializedRenderPipelines<TonemappingPipeline>>,

--- a/crates/bevy_core_pipeline/src/upscaling/mod.rs
+++ b/crates/bevy_core_pipeline/src/upscaling/mod.rs
@@ -16,7 +16,7 @@ impl Plugin for UpscalingPlugin {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app.add_systems(
                 Render,
-                queue_view_upscaling_pipelines.in_set(RenderSet::Queue),
+                prepare_view_upscaling_pipelines.in_set(RenderSet::Prepare),
             );
         }
     }
@@ -25,7 +25,7 @@ impl Plugin for UpscalingPlugin {
 #[derive(Component)]
 pub struct ViewUpscalingPipeline(CachedRenderPipelineId);
 
-fn queue_view_upscaling_pipelines(
+fn prepare_view_upscaling_pipelines(
     mut commands: Commands,
     pipeline_cache: Res<PipelineCache>,
     mut pipelines: ResMut<SpecializedRenderPipelines<BlitPipeline>>,

--- a/crates/bevy_derive/src/derefs.rs
+++ b/crates/bevy_derive/src/derefs.rs
@@ -68,9 +68,11 @@ fn get_deref_field(ast: &DeriveInput, is_mut: bool) -> syn::Result<(Member, &Typ
             let mut selected_field: Option<(Member, &Type)> = None;
             for (index, field) in data_struct.fields.iter().enumerate() {
                 for attr in &field.attrs {
-                    if !attr.meta.require_path_only()?.is_ident(DEREF_ATTR) {
+                    if !attr.meta.path().is_ident(DEREF_ATTR) {
                         continue;
                     }
+
+                    attr.meta.require_path_only()?;
 
                     if selected_field.is_some() {
                         return Err(syn::Error::new_spanned(

--- a/crates/bevy_ecs/examples/change_detection.rs
+++ b/crates/bevy_ecs/examples/change_detection.rs
@@ -1,4 +1,4 @@
-use bevy_ecs::prelude::*;
+use bevy_ecs::{prelude::*, schedule::ScheduleLabel};
 use rand::Rng;
 use std::ops::Deref;
 

--- a/crates/bevy_ecs/examples/change_detection.rs
+++ b/crates/bevy_ecs/examples/change_detection.rs
@@ -1,4 +1,4 @@
-use bevy_ecs::{prelude::*, schedule::ScheduleLabel};
+use bevy_ecs::prelude::*;
 use rand::Rng;
 use std::ops::Deref;
 

--- a/crates/bevy_ecs/examples/events.rs
+++ b/crates/bevy_ecs/examples/events.rs
@@ -1,4 +1,4 @@
-use bevy_ecs::prelude::*;
+use bevy_ecs::{prelude::*, schedule::ScheduleLabel};
 
 // In this example a system sends a custom event with a 50/50 chance during any frame.
 // If an event was send, it will be printed by the console in a receiving system.

--- a/crates/bevy_ecs/examples/events.rs
+++ b/crates/bevy_ecs/examples/events.rs
@@ -1,4 +1,4 @@
-use bevy_ecs::{prelude::*, schedule::ScheduleLabel};
+use bevy_ecs::prelude::*;
 
 // In this example a system sends a custom event with a 50/50 chance during any frame.
 // If an event was send, it will be printed by the console in a receiving system.

--- a/crates/bevy_ecs/examples/resources.rs
+++ b/crates/bevy_ecs/examples/resources.rs
@@ -1,4 +1,4 @@
-use bevy_ecs::prelude::*;
+use bevy_ecs::{prelude::*, schedule::ScheduleLabel};
 use rand::Rng;
 use std::ops::Deref;
 

--- a/crates/bevy_ecs/examples/resources.rs
+++ b/crates/bevy_ecs/examples/resources.rs
@@ -1,4 +1,4 @@
-use bevy_ecs::{prelude::*, schedule::ScheduleLabel};
+use bevy_ecs::prelude::*;
 use rand::Rng;
 use std::ops::Deref;
 

--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -135,7 +135,7 @@ pub fn derive_world_query_impl(input: TokenStream) -> TokenStream {
             "#[derive(WorldQuery)]` only supports structs",
         )
         .into_compile_error()
-        .into()
+        .into();
     };
 
     let mut field_attrs = Vec::new();

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -251,10 +251,17 @@ pub fn impl_param_set(_input: TokenStream) -> TokenStream {
 pub fn derive_system_param(input: TokenStream) -> TokenStream {
     let token_stream = input.clone();
     let ast = parse_macro_input!(input as DeriveInput);
-    let syn::Data::Struct(syn::DataStruct { fields: field_definitions, .. }) = ast.data else {
-        return syn::Error::new(ast.span(), "Invalid `SystemParam` type: expected a `struct`")
-            .into_compile_error()
-            .into();
+    let syn::Data::Struct(syn::DataStruct {
+        fields: field_definitions,
+        ..
+    }) = ast.data
+    else {
+        return syn::Error::new(
+            ast.span(),
+            "Invalid `SystemParam` type: expected a `struct`",
+        )
+        .into_compile_error()
+        .into();
     };
     let path = bevy_ecs_path();
 

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -149,7 +149,7 @@ pub trait DetectChangesMut: DetectChanges {
     /// # score_changed.initialize(&mut world);
     /// # score_changed.run((), &mut world);
     /// #
-    /// # let mut schedule = Schedule::new();
+    /// # let mut schedule = Schedule::default();
     /// # schedule.add_systems(reset_score);
     /// #
     /// # // first time `reset_score` runs, the score is changed.
@@ -214,7 +214,7 @@ pub trait DetectChangesMut: DetectChanges {
     /// # score_changed_event.initialize(&mut world);
     /// # score_changed_event.run((), &mut world);
     /// #
-    /// # let mut schedule = Schedule::new();
+    /// # let mut schedule = Schedule::default();
     /// # schedule.add_systems(reset_score);
     /// #
     /// # // first time `reset_score` runs, the score is changed.

--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -1,11 +1,11 @@
 use crate::{entity::Entity, world::World};
-use bevy_utils::{Entry, HashMap};
+use bevy_utils::HashMap;
 
 /// Operation to map all contained [`Entity`] fields in a type to new values.
 ///
 /// As entity IDs are valid only for the [`World`] they're sourced from, using [`Entity`]
 /// as references in components copied from another world will be invalid. This trait
-/// allows defining custom mappings for these references via [`EntityMap`].
+/// allows defining custom mappings for these references via [`HashMap<Entity, Entity>`]
 ///
 /// Implementing this trait correctly is required for properly loading components
 /// with entity references from scenes.
@@ -32,112 +32,29 @@ use bevy_utils::{Entry, HashMap};
 ///
 /// [`World`]: crate::world::World
 pub trait MapEntities {
-    /// Updates all [`Entity`] references stored inside using `entity_map`.
+    /// Updates all [`Entity`] references stored inside using `entity_mapper`.
     ///
     /// Implementors should look up any and all [`Entity`] values stored within and
     /// update them to the mapped values via `entity_mapper`.
     fn map_entities(&mut self, entity_mapper: &mut EntityMapper);
 }
 
-/// A mapping from one set of entities to another.
-///
-/// The API generally follows [`HashMap`], but each [`Entity`] is returned by value, as they are [`Copy`].
-///
-/// This is typically used to coordinate data transfer between sets of entities, such as between a scene and the world
-/// or over the network. This is required as [`Entity`] identifiers are opaque; you cannot and do not want to reuse
-/// identifiers directly.
-///
-/// On its own, an `EntityMap` is not capable of allocating new entity identifiers, which is needed to map references
-/// to entities that lie outside the source entity set. To do this, an `EntityMap` can be wrapped in an
-/// [`EntityMapper`] which scopes it to a particular destination [`World`] and allows new identifiers to be allocated.
-/// This functionality can be accessed through [`Self::world_scope()`].
-#[derive(Default, Debug)]
-pub struct EntityMap {
-    map: HashMap<Entity, Entity>,
-}
-
-impl EntityMap {
-    /// Inserts an entities pair into the map.
-    ///
-    /// If the map did not have `from` present, [`None`] is returned.
-    ///
-    /// If the map did have `from` present, the value is updated, and the old value is returned.
-    pub fn insert(&mut self, from: Entity, to: Entity) -> Option<Entity> {
-        self.map.insert(from, to)
-    }
-
-    /// Removes an `entity` from the map, returning the mapped value of it if the `entity` was previously in the map.
-    pub fn remove(&mut self, entity: Entity) -> Option<Entity> {
-        self.map.remove(&entity)
-    }
-
-    /// Gets the given entity's corresponding entry in the map for in-place manipulation.
-    pub fn entry(&mut self, entity: Entity) -> Entry<'_, Entity, Entity> {
-        self.map.entry(entity)
-    }
-
-    /// Returns the corresponding mapped entity.
-    pub fn get(&self, entity: Entity) -> Option<Entity> {
-        self.map.get(&entity).copied()
-    }
-
-    /// An iterator visiting all keys in arbitrary order.
-    pub fn keys(&self) -> impl Iterator<Item = Entity> + '_ {
-        self.map.keys().cloned()
-    }
-
-    /// An iterator visiting all values in arbitrary order.
-    pub fn values(&self) -> impl Iterator<Item = Entity> + '_ {
-        self.map.values().cloned()
-    }
-
-    /// Returns the number of elements in the map.
-    pub fn len(&self) -> usize {
-        self.map.len()
-    }
-
-    /// Returns true if the map contains no elements.
-    pub fn is_empty(&self) -> bool {
-        self.map.is_empty()
-    }
-
-    /// An iterator visiting all (key, value) pairs in arbitrary order.
-    pub fn iter(&self) -> impl Iterator<Item = (Entity, Entity)> + '_ {
-        self.map.iter().map(|(from, to)| (*from, *to))
-    }
-
-    /// Clears the map, removing all entity pairs. Keeps the allocated memory for reuse.
-    pub fn clear(&mut self) {
-        self.map.clear();
-    }
-
-    /// Creates an [`EntityMapper`] from this [`EntityMap`] and scoped to the provided [`World`], then calls the
-    /// provided function with it. This allows one to allocate new entity references in the provided `World` that are
-    /// guaranteed to never point at a living entity now or in the future. This functionality is useful for safely
-    /// mapping entity identifiers that point at entities outside the source world. The passed function, `f`, is called
-    /// within the scope of the passed world. Its return value is then returned from `world_scope` as the generic type
-    /// parameter `R`.
-    pub fn world_scope<R>(
-        &mut self,
-        world: &mut World,
-        f: impl FnOnce(&mut World, &mut EntityMapper) -> R,
-    ) -> R {
-        let mut mapper = EntityMapper::new(self, world);
-        let result = f(world, &mut mapper);
-        mapper.finish(world);
-        result
-    }
-}
-
-/// A wrapper for [`EntityMap`], augmenting it with the ability to allocate new [`Entity`] references in a destination
+/// A wrapper for [`HashMap<Entity, Entity>`], augmenting it with the ability to allocate new [`Entity`] references in a destination
 /// world. These newly allocated references are guaranteed to never point to any living entity in that world.
 ///
 /// References are allocated by returning increasing generations starting from an internally initialized base
 /// [`Entity`]. After it is finished being used by [`MapEntities`] implementations, this entity is despawned and the
 /// requisite number of generations reserved.
 pub struct EntityMapper<'m> {
-    /// The wrapped [`EntityMap`].
-    map: &'m mut EntityMap,
+    /// A mapping from one set of entities to another.
+    ///
+    /// This is typically used to coordinate data transfer between sets of entities, such as between a scene and the world
+    /// or over the network. This is required as [`Entity`] identifiers are opaque; you cannot and do not want to reuse
+    /// identifiers directly.
+    ///
+    /// On its own, a [`HashMap<Entity, Entity>`] is not capable of allocating new entity identifiers, which is needed to map references
+    /// to entities that lie outside the source entity set. This functionality can be accessed through [`EntityMapper::world_scope()`].
+    map: &'m mut HashMap<Entity, Entity>,
     /// A base [`Entity`] used to allocate new references.
     dead_start: Entity,
     /// The number of generations this mapper has allocated thus far.
@@ -147,7 +64,7 @@ pub struct EntityMapper<'m> {
 impl<'m> EntityMapper<'m> {
     /// Returns the corresponding mapped entity or reserves a new dead entity ID if it is absent.
     pub fn get_or_reserve(&mut self, entity: Entity) -> Entity {
-        if let Some(mapped) = self.map.get(entity) {
+        if let Some(&mapped) = self.map.get(&entity) {
             return mapped;
         }
 
@@ -163,21 +80,21 @@ impl<'m> EntityMapper<'m> {
         new
     }
 
-    /// Gets a reference to the underlying [`EntityMap`].
-    pub fn get_map(&'m self) -> &'m EntityMap {
+    /// Gets a reference to the underlying [`HashMap<Entity, Entity>`].
+    pub fn get_map(&'m self) -> &'m HashMap<Entity, Entity> {
         self.map
     }
 
-    /// Gets a mutable reference to the underlying [`EntityMap`]
-    pub fn get_map_mut(&'m mut self) -> &'m mut EntityMap {
+    /// Gets a mutable reference to the underlying [`HashMap<Entity, Entity>`].
+    pub fn get_map_mut(&'m mut self) -> &'m mut HashMap<Entity, Entity> {
         self.map
     }
 
     /// Creates a new [`EntityMapper`], spawning a temporary base [`Entity`] in the provided [`World`]
-    fn new(map: &'m mut EntityMap, world: &mut World) -> Self {
+    fn new(map: &'m mut HashMap<Entity, Entity>, world: &mut World) -> Self {
         Self {
             map,
-            // SAFETY: Entities data is kept in a valid state via `EntityMap::world_scope`
+            // SAFETY: Entities data is kept in a valid state via `EntityMapper::world_scope`
             dead_start: unsafe { world.entities_mut().alloc() },
             generations: 0,
         }
@@ -193,19 +110,40 @@ impl<'m> EntityMapper<'m> {
         assert!(entities.free(self.dead_start).is_some());
         assert!(entities.reserve_generations(self.dead_start.index, self.generations));
     }
+
+    /// Creates an [`EntityMapper`] from a provided [`World`] and [`HashMap<Entity, Entity>`], then calls the
+    /// provided function with it. This allows one to allocate new entity references in this [`World`] that are
+    /// guaranteed to never point at a living entity now or in the future. This functionality is useful for safely
+    /// mapping entity identifiers that point at entities outside the source world. The passed function, `f`, is called
+    /// within the scope of this world. Its return value is then returned from `world_scope` as the generic type
+    /// parameter `R`.
+    pub fn world_scope<R>(
+        entity_map: &'m mut HashMap<Entity, Entity>,
+        world: &mut World,
+        f: impl FnOnce(&mut World, &mut Self) -> R,
+    ) -> R {
+        let mut mapper = Self::new(entity_map, world);
+        let result = f(world, &mut mapper);
+        mapper.finish(world);
+        result
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{EntityMap, EntityMapper};
-    use crate::{entity::Entity, world::World};
+    use bevy_utils::HashMap;
+
+    use crate::{
+        entity::{Entity, EntityMapper},
+        world::World,
+    };
 
     #[test]
     fn entity_mapper() {
         const FIRST_IDX: u32 = 1;
         const SECOND_IDX: u32 = 2;
 
-        let mut map = EntityMap::default();
+        let mut map = HashMap::default();
         let mut world = World::new();
         let mut mapper = EntityMapper::new(&mut map, &mut world);
 
@@ -232,10 +170,10 @@ mod tests {
 
     #[test]
     fn world_scope_reserves_generations() {
-        let mut map = EntityMap::default();
+        let mut map = HashMap::default();
         let mut world = World::new();
 
-        let dead_ref = map.world_scope(&mut world, |_, mapper| {
+        let dead_ref = EntityMapper::world_scope(&mut map, &mut world, |_, mapper| {
             mapper.get_or_reserve(Entity::new(0, 0))
         });
 

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -1034,7 +1034,7 @@ mod tests {
         world.send_event(TestEvent { i: 3 });
         world.send_event(TestEvent { i: 4 });
 
-        let mut schedule = Schedule::new();
+        let mut schedule = Schedule::default();
         schedule.add_systems(|mut events: EventReader<TestEvent>| {
             let mut iter = events.iter();
 

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -228,14 +228,27 @@ impl<E: Event> Events<E> {
 
     /// Swaps the event buffers and clears the oldest event buffer. In general, this should be
     /// called once per frame/update.
+    ///
+    /// If you need access to the events that were removed, consider using [`Events::update_drain`].
     pub fn update(&mut self) {
+        let _ = self.update_drain();
+    }
+
+    /// Swaps the event buffers and drains the oldest event buffer, returning an iterator
+    /// of all events that were removed. In general, this should be called once per frame/update.
+    ///
+    /// If you do not need to take ownership of the removed events, use [`Events::update`] instead.
+    #[must_use = "If you do not need the returned events, call .update() instead."]
+    pub fn update_drain(&mut self) -> impl Iterator<Item = E> + '_ {
         std::mem::swap(&mut self.events_a, &mut self.events_b);
-        self.events_b.clear();
+        let iter = self.events_b.events.drain(..);
         self.events_b.start_event_count = self.event_count;
         debug_assert_eq!(
             self.events_a.start_event_count + self.events_a.len(),
             self.events_b.start_event_count
         );
+
+        iter.map(|e| e.event)
     }
 
     /// A system that calls [`Events::update`] once per frame.
@@ -725,7 +738,7 @@ impl<'a, E: Event> ExactSizeIterator for EventIteratorWithId<'a, E> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{prelude::World, system::SystemState};
+    use crate::system::assert_is_read_only_system;
 
     use super::*;
 
@@ -982,6 +995,31 @@ mod tests {
         assert!(is_empty, "EventReader should be empty");
     }
 
+    #[test]
+    fn test_update_drain() {
+        let mut events = Events::<TestEvent>::default();
+        let mut reader = events.get_reader();
+
+        events.send(TestEvent { i: 0 });
+        events.send(TestEvent { i: 1 });
+        assert_eq!(reader.iter(&events).count(), 2);
+
+        let mut old_events = Vec::from_iter(events.update_drain());
+        assert!(old_events.is_empty());
+
+        events.send(TestEvent { i: 2 });
+        assert_eq!(reader.iter(&events).count(), 1);
+
+        old_events.extend(events.update_drain());
+        assert_eq!(old_events.len(), 2);
+
+        old_events.extend(events.update_drain());
+        assert_eq!(
+            old_events,
+            &[TestEvent { i: 0 }, TestEvent { i: 1 }, TestEvent { i: 2 }]
+        );
+    }
+
     #[allow(clippy::iter_nth_zero)]
     #[test]
     fn test_event_iter_nth() {
@@ -1053,13 +1091,8 @@ mod tests {
 
     #[test]
     fn ensure_reader_readonly() {
-        fn read_for<E: Event>() {
-            let mut world = World::new();
-            world.init_resource::<Events<E>>();
-            let mut state = SystemState::<EventReader<E>>::new(&mut world);
-            // This can only work if EventReader only reads the world
-            let _reader = state.get(&world);
-        }
-        read_for::<EmptyTestEvent>();
+        fn reader_system(_: EventReader<EmptyTestEvent>) {}
+
+        assert_is_read_only_system(reader_system);
     }
 }

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -390,12 +390,12 @@ impl<'w, 's, E: Event> EventReader<'w, 's, E> {
     /// Iterates over the events this [`EventReader`] has not seen yet. This updates the
     /// [`EventReader`]'s event counter, which means subsequent event reads will not include events
     /// that happened before now.
-    pub fn iter(&mut self) -> ManualEventIterator<'_, E> {
+    pub fn iter(&mut self) -> EventIterator<'_, E> {
         self.reader.iter(&self.events)
     }
 
     /// Like [`iter`](Self::iter), except also returning the [`EventId`] of the events.
-    pub fn iter_with_id(&mut self) -> ManualEventIteratorWithId<'_, E> {
+    pub fn iter_with_id(&mut self) -> EventIteratorWithId<'_, E> {
         self.reader.iter_with_id(&self.events)
     }
 
@@ -442,7 +442,7 @@ impl<'w, 's, E: Event> EventReader<'w, 's, E> {
 
 impl<'a, 'w, 's, E: Event> IntoIterator for &'a mut EventReader<'w, 's, E> {
     type Item = &'a E;
-    type IntoIter = ManualEventIterator<'a, E>;
+    type IntoIter = EventIterator<'a, E>;
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
@@ -541,16 +541,13 @@ impl<E: Event> Default for ManualEventReader<E> {
 #[allow(clippy::len_without_is_empty)] // Check fails since the is_empty implementation has a signature other than `(&self) -> bool`
 impl<E: Event> ManualEventReader<E> {
     /// See [`EventReader::iter`]
-    pub fn iter<'a>(&'a mut self, events: &'a Events<E>) -> ManualEventIterator<'a, E> {
+    pub fn iter<'a>(&'a mut self, events: &'a Events<E>) -> EventIterator<'a, E> {
         self.iter_with_id(events).without_id()
     }
 
     /// See [`EventReader::iter_with_id`]
-    pub fn iter_with_id<'a>(
-        &'a mut self,
-        events: &'a Events<E>,
-    ) -> ManualEventIteratorWithId<'a, E> {
-        ManualEventIteratorWithId::new(self, events)
+    pub fn iter_with_id<'a>(&'a mut self, events: &'a Events<E>) -> EventIteratorWithId<'a, E> {
+        EventIteratorWithId::new(self, events)
     }
 
     /// See [`EventReader::len`]
@@ -585,11 +582,18 @@ impl<E: Event> ManualEventReader<E> {
 
 /// An iterator that yields any unread events from an [`EventReader`] or [`ManualEventReader`].
 #[derive(Debug)]
-pub struct ManualEventIterator<'a, E: Event> {
-    iter: ManualEventIteratorWithId<'a, E>,
+pub struct EventIterator<'a, E: Event> {
+    iter: EventIteratorWithId<'a, E>,
 }
 
-impl<'a, E: Event> Iterator for ManualEventIterator<'a, E> {
+/// An iterator that yields any unread events from an [`EventReader`] or [`ManualEventReader`].
+///
+/// This is a type alias for [`EventIterator`], which used to be called `ManualEventIterator`.
+/// This type alias will be removed in the next release of bevy, so you should use [`EventIterator`] directly instead.
+#[deprecated = "This type has been renamed to `EventIterator`."]
+pub type ManualEventIterator<'a, E> = EventIterator<'a, E>;
+
+impl<'a, E: Event> Iterator for EventIterator<'a, E> {
     type Item = &'a E;
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|(event, _)| event)
@@ -615,7 +619,7 @@ impl<'a, E: Event> Iterator for ManualEventIterator<'a, E> {
     }
 }
 
-impl<'a, E: Event> ExactSizeIterator for ManualEventIterator<'a, E> {
+impl<'a, E: Event> ExactSizeIterator for EventIterator<'a, E> {
     fn len(&self) -> usize {
         self.iter.len()
     }
@@ -623,13 +627,20 @@ impl<'a, E: Event> ExactSizeIterator for ManualEventIterator<'a, E> {
 
 /// An iterator that yields any unread events (and their IDs) from an [`EventReader`] or [`ManualEventReader`].
 #[derive(Debug)]
-pub struct ManualEventIteratorWithId<'a, E: Event> {
+pub struct EventIteratorWithId<'a, E: Event> {
     reader: &'a mut ManualEventReader<E>,
     chain: Chain<Iter<'a, EventInstance<E>>, Iter<'a, EventInstance<E>>>,
     unread: usize,
 }
 
-impl<'a, E: Event> ManualEventIteratorWithId<'a, E> {
+/// An iterator that yields any unread events (and their IDs) from an [`EventReader`] or [`ManualEventReader`].
+///
+/// This is a type alias for [`EventIteratorWithId`], which used to be called `ManualEventIteratorWithId`.
+/// This type alias will be removed in the next release of bevy, so you should use [`EventIteratorWithId`] directly instead.
+#[deprecated = "This type has been renamed to `EventIteratorWithId`."]
+pub type ManualEventIteratorWithId<'a, E> = EventIteratorWithId<'a, E>;
+
+impl<'a, E: Event> EventIteratorWithId<'a, E> {
     /// Creates a new iterator that yields any `events` that have not yet been seen by `reader`.
     pub fn new(reader: &'a mut ManualEventReader<E>, events: &'a Events<E>) -> Self {
         let a_index = (reader.last_event_count).saturating_sub(events.events_a.start_event_count);
@@ -652,12 +663,12 @@ impl<'a, E: Event> ManualEventIteratorWithId<'a, E> {
     }
 
     /// Iterate over only the events.
-    pub fn without_id(self) -> ManualEventIterator<'a, E> {
-        ManualEventIterator { iter: self }
+    pub fn without_id(self) -> EventIterator<'a, E> {
+        EventIterator { iter: self }
     }
 }
 
-impl<'a, E: Event> Iterator for ManualEventIteratorWithId<'a, E> {
+impl<'a, E: Event> Iterator for EventIteratorWithId<'a, E> {
     type Item = (&'a E, EventId<E>);
     fn next(&mut self) -> Option<Self::Item> {
         match self
@@ -706,7 +717,7 @@ impl<'a, E: Event> Iterator for ManualEventIteratorWithId<'a, E> {
     }
 }
 
-impl<'a, E: Event> ExactSizeIterator for ManualEventIteratorWithId<'a, E> {
+impl<'a, E: Event> ExactSizeIterator for EventIteratorWithId<'a, E> {
     fn len(&self) -> usize {
         self.unread
     }

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -30,6 +30,10 @@ pub mod prelude {
     #[doc(hidden)]
     #[cfg(feature = "bevy_reflect")]
     pub use crate::reflect::{AppTypeRegistry, ReflectComponent, ReflectResource};
+    #[allow(deprecated)]
+    pub use crate::system::adapter::{
+        self as system_adapter, dbg, error, ignore, info, unwrap, warn,
+    };
     #[doc(hidden)]
     pub use crate::{
         bundle::Bundle,
@@ -45,8 +49,6 @@ pub mod prelude {
             OnEnter, OnExit, OnTransition, Schedule, Schedules, State, States, SystemSet,
         },
         system::{
-            adapter as system_adapter,
-            adapter::{dbg, error, ignore, info, unwrap, warn},
             Commands, Deferred, In, IntoSystem, Local, NonSend, NonSendMut, ParallelCommands,
             ParamSet, Query, ReadOnlySystem, Res, ResMut, Resource, System, SystemParamFunction,
         },

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -789,7 +789,7 @@ mod tests {
             }
         }
 
-        let mut schedule = Schedule::new();
+        let mut schedule = Schedule::default();
         schedule.add_systems((propagate_system, modify_system).chain());
         schedule.run(&mut world);
         world.clear_trackers();

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -39,12 +39,11 @@ pub struct QueryState<Q: WorldQuery, F: ReadOnlyWorldQuery = ()> {
 
 impl<Q: WorldQuery, F: ReadOnlyWorldQuery> std::fmt::Debug for QueryState<Q, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "QueryState<Q, F> matched_table_ids: {} matched_archetype_ids: {}",
-            self.matched_table_ids.len(),
-            self.matched_archetype_ids.len()
-        )
+        f.debug_struct("QueryState")
+            .field("world_id", &self.world_id)
+            .field("matched_table_count", &self.matched_table_ids.len())
+            .field("matched_archetype_count", &self.matched_archetype_ids.len())
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/bevy_ecs/src/reflect/bundle.rs
+++ b/crates/bevy_ecs/src/reflect/bundle.rs
@@ -1,0 +1,218 @@
+//! Definitions for [`Bundle`] reflection.
+//!
+//! This module exports two types: [`ReflectBundleFns`] and [`ReflectBundle`].
+//!
+//! Same as [`super::component`], but for bundles.
+use std::any::TypeId;
+
+use crate::{
+    prelude::Bundle,
+    world::{EntityMut, FromWorld, World},
+};
+use bevy_reflect::{FromType, Reflect, ReflectRef, TypeRegistry};
+
+use super::ReflectComponent;
+
+/// A struct used to operate on reflected [`Bundle`] of a type.
+///
+/// A [`ReflectBundle`] for type `T` can be obtained via
+/// [`bevy_reflect::TypeRegistration::data`].
+#[derive(Clone)]
+pub struct ReflectBundle(ReflectBundleFns);
+
+/// The raw function pointers needed to make up a [`ReflectBundle`].
+///
+/// The also [`super::component::ReflectComponentFns`].
+#[derive(Clone)]
+pub struct ReflectBundleFns {
+    /// Function pointer implementing [`ReflectBundle::from_world()`].
+    pub from_world: fn(&mut World) -> Box<dyn Reflect>,
+    /// Function pointer implementing [`ReflectBundle::insert()`].
+    pub insert: fn(&mut EntityMut, &dyn Reflect),
+    /// Function pointer implementing [`ReflectBundle::apply()`].
+    pub apply: fn(&mut EntityMut, &dyn Reflect, &TypeRegistry),
+    /// Function pointer implementing [`ReflectBundle::apply_or_insert()`].
+    pub apply_or_insert: fn(&mut EntityMut, &dyn Reflect, &TypeRegistry),
+    /// Function pointer implementing [`ReflectBundle::remove()`].
+    pub remove: fn(&mut EntityMut),
+}
+
+impl ReflectBundleFns {
+    /// Get the default set of [`ReflectBundleFns`] for a specific bundle type using its
+    /// [`FromType`] implementation.
+    ///
+    /// This is useful if you want to start with the default implementation before overriding some
+    /// of the functions to create a custom implementation.
+    pub fn new<T: Bundle + Reflect + FromWorld>() -> Self {
+        <ReflectBundle as FromType<T>>::from_type().0
+    }
+}
+
+impl ReflectBundle {
+    /// Constructs default reflected [`Bundle`] from world using [`from_world()`](FromWorld::from_world).
+    pub fn from_world(&self, world: &mut World) -> Box<dyn Reflect> {
+        (self.0.from_world)(world)
+    }
+
+    /// Insert a reflected [`Bundle`] into the entity like [`insert()`](crate::world::EntityMut::insert).
+    pub fn insert(&self, entity: &mut EntityMut, bundle: &dyn Reflect) {
+        (self.0.insert)(entity, bundle);
+    }
+
+    /// Uses reflection to set the value of this [`Bundle`] type in the entity to the given value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if there is no [`Bundle`] of the given type.
+    pub fn apply(&self, entity: &mut EntityMut, bundle: &dyn Reflect, registry: &TypeRegistry) {
+        (self.0.apply)(entity, bundle, registry);
+    }
+
+    /// Uses reflection to set the value of this [`Bundle`] type in the entity to the given value or insert a new one if it does not exist.
+    pub fn apply_or_insert(
+        &self,
+        entity: &mut EntityMut,
+        bundle: &dyn Reflect,
+        registry: &TypeRegistry,
+    ) {
+        (self.0.apply_or_insert)(entity, bundle, registry);
+    }
+
+    /// Removes this [`Bundle`] type from the entity. Does nothing if it doesn't exist.
+    pub fn remove(&self, entity: &mut EntityMut) {
+        (self.0.remove)(entity);
+    }
+
+    /// Create a custom implementation of [`ReflectBundle`].
+    ///
+    /// This is an advanced feature,
+    /// useful for scripting implementations,
+    /// that should not be used by most users
+    /// unless you know what you are doing.
+    ///
+    /// Usually you should derive [`Reflect`] and add the `#[reflect(Bundle)]` bundle
+    /// to generate a [`ReflectBundle`] implementation automatically.
+    ///
+    /// See [`ReflectBundleFns`] for more information.
+    pub fn new(fns: ReflectBundleFns) -> Self {
+        Self(fns)
+    }
+
+    /// The underlying function pointers implementing methods on `ReflectBundle`.
+    ///
+    /// This is useful when you want to keep track locally of an individual
+    /// function pointer.
+    ///
+    /// Calling [`TypeRegistry::get`] followed by
+    /// [`TypeRegistration::data::<ReflectBundle>`] can be costly if done several
+    /// times per frame. Consider cloning [`ReflectBundle`] and keeping it
+    /// between frames, cloning a `ReflectBundle` is very cheap.
+    ///
+    /// If you only need a subset of the methods on `ReflectBundle`,
+    /// use `fn_pointers` to get the underlying [`ReflectBundleFns`]
+    /// and copy the subset of function pointers you care about.
+    ///
+    /// [`TypeRegistration::data::<ReflectBundle>`]: bevy_reflect::TypeRegistration::data
+    /// [`TypeRegistry::get`]: bevy_reflect::TypeRegistry::get
+    pub fn fn_pointers(&self) -> &ReflectBundleFns {
+        &self.0
+    }
+}
+
+impl<B: Bundle + Reflect + FromWorld> FromType<B> for ReflectBundle {
+    fn from_type() -> Self {
+        ReflectBundle(ReflectBundleFns {
+            from_world: |world| Box::new(B::from_world(world)),
+            insert: |entity, reflected_bundle| {
+                let mut bundle = entity.world_scope(|world| B::from_world(world));
+                bundle.apply(reflected_bundle);
+                entity.insert(bundle);
+            },
+            apply: |entity, reflected_bundle, registry| {
+                let mut bundle = entity.world_scope(|world| B::from_world(world));
+                bundle.apply(reflected_bundle);
+
+                match bundle.reflect_ref() {
+                    ReflectRef::Struct(bundle) => bundle
+                        .iter_fields()
+                        .for_each(|field| insert_field::<B>(entity, field, registry)),
+                    ReflectRef::Tuple(bundle) => bundle
+                        .iter_fields()
+                        .for_each(|field| insert_field::<B>(entity, field, registry)),
+                    _ => panic!(
+                        "expected bundle `{}` to be named struct or tuple",
+                        std::any::type_name::<B>()
+                    ),
+                }
+            },
+            apply_or_insert: |entity, reflected_bundle, registry| {
+                let mut bundle = entity.world_scope(|world| B::from_world(world));
+                bundle.apply(reflected_bundle);
+
+                match bundle.reflect_ref() {
+                    ReflectRef::Struct(bundle) => bundle
+                        .iter_fields()
+                        .for_each(|field| apply_or_insert_field::<B>(entity, field, registry)),
+                    ReflectRef::Tuple(bundle) => bundle
+                        .iter_fields()
+                        .for_each(|field| apply_or_insert_field::<B>(entity, field, registry)),
+                    _ => panic!(
+                        "expected bundle `{}` to be named struct or tuple",
+                        std::any::type_name::<B>()
+                    ),
+                }
+            },
+            remove: |entity| {
+                entity.remove::<B>();
+            },
+        })
+    }
+}
+
+fn insert_field<B: 'static>(entity: &mut EntityMut, field: &dyn Reflect, registry: &TypeRegistry) {
+    if let Some(reflect_component) = registry.get_type_data::<ReflectComponent>(field.type_id()) {
+        reflect_component.apply(entity, field);
+    } else if let Some(reflect_bundle) = registry.get_type_data::<ReflectBundle>(field.type_id()) {
+        reflect_bundle.apply(entity, field, registry);
+    } else {
+        entity.world_scope(|world| {
+            if world.components().get_id(TypeId::of::<B>()).is_some() {
+                panic!(
+                    "no `ReflectComponent` registration found for `{}`",
+                    field.type_name()
+                );
+            };
+        });
+
+        panic!(
+            "no `ReflectBundle` registration found for `{}`",
+            field.type_name()
+        )
+    }
+}
+
+fn apply_or_insert_field<B: 'static>(
+    entity: &mut EntityMut,
+    field: &dyn Reflect,
+    registry: &TypeRegistry,
+) {
+    if let Some(reflect_component) = registry.get_type_data::<ReflectComponent>(field.type_id()) {
+        reflect_component.apply_or_insert(entity, field);
+    } else if let Some(reflect_bundle) = registry.get_type_data::<ReflectBundle>(field.type_id()) {
+        reflect_bundle.apply_or_insert(entity, field, registry);
+    } else {
+        entity.world_scope(|world| {
+            if world.components().get_id(TypeId::of::<B>()).is_some() {
+                panic!(
+                    "no `ReflectComponent` registration found for `{}`",
+                    field.type_name()
+                );
+            };
+        });
+
+        panic!(
+            "no `ReflectBundle` registration found for `{}`",
+            field.type_name()
+        )
+    }
+}

--- a/crates/bevy_ecs/src/reflect/entity_commands.rs
+++ b/crates/bevy_ecs/src/reflect/entity_commands.rs
@@ -1,0 +1,452 @@
+use crate::prelude::Mut;
+use crate::reflect::AppTypeRegistry;
+use crate::system::{Command, EntityCommands, Resource};
+use crate::{entity::Entity, reflect::ReflectComponent, world::World};
+use bevy_reflect::{Reflect, TypeRegistry};
+use std::borrow::Cow;
+use std::marker::PhantomData;
+
+/// An extension trait for [`EntityCommands`] for reflection related functions
+pub trait ReflectCommandExt {
+    /// Adds the given boxed reflect component to the entity using the reflection data in
+    /// [`AppTypeRegistry`].
+    ///
+    /// This will overwrite any previous component of the same type.
+    ///
+    /// # Panics
+    ///
+    /// - If the entity doesn't exist.
+    /// - If [`AppTypeRegistry`] does not have the reflection data for the given [`Component`](crate::component::Component).
+    /// - If the component data is invalid. See [`Reflect::apply`] for further details.
+    /// - If [`AppTypeRegistry`] is not present in the [`World`].
+    ///
+    /// # Note
+    ///
+    /// Prefer to use the typed [`EntityCommands::insert`] if possible. Adding a reflected component
+    /// is much slower.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// // Note that you need to register the component type in the AppTypeRegistry prior to using
+    /// // reflection. You can use the helpers on the App with `app.register_type::<ComponentA>()`
+    /// // or write to the TypeRegistry directly to register all your components
+    ///
+    /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::reflect::ReflectCommandExt;
+    /// # use bevy_reflect::{FromReflect, FromType, Reflect, TypeRegistry};
+    /// // A resource that can hold any component that implements reflect as a boxed reflect component
+    /// #[derive(Resource)]
+    /// struct Prefab{
+    ///     component: Box<dyn Reflect>,
+    /// }
+    /// #[derive(Component, Reflect, Default)]
+    /// #[reflect(Component)]
+    /// struct ComponentA(u32);
+    ///
+    /// #[derive(Component, Reflect, Default)]
+    /// #[reflect(Component)]
+    /// struct ComponentB(String);
+    ///
+    /// fn insert_reflect_component(
+    ///     mut commands: Commands,
+    ///     mut prefab: ResMut<Prefab>
+    ///     ) {
+    ///     // Create a set of new boxed reflect components to use
+    ///     let boxed_reflect_component_a: Box<dyn Reflect> = Box::new(ComponentA(916));
+    ///     let boxed_reflect_component_b: Box<dyn Reflect>  = Box::new(ComponentB("NineSixteen".to_string()));
+    ///
+    ///     // You can overwrite the component in the resource with either ComponentA or ComponentB
+    ///     prefab.component = boxed_reflect_component_a;
+    ///     prefab.component = boxed_reflect_component_b;
+    ///     
+    ///     // No matter which component is in the resource and without knowing the exact type, you can
+    ///     // use the insert_reflect entity command to insert that component into an entity.
+    ///     commands
+    ///         .spawn_empty()
+    ///         .insert_reflect(prefab.component.clone_value());
+    /// }
+    ///
+    /// ```
+    fn insert_reflect(&mut self, component: Box<dyn Reflect>) -> &mut Self;
+
+    /// Same as [`insert_reflect`](ReflectCommandExt::insert_reflect), but using the `T` resource as type registry instead of
+    /// `AppTypeRegistry`.
+    ///
+    /// # Panics
+    ///
+    /// - If the given [`Resource`] is not present in the [`World`].
+    ///
+    /// # Note
+    ///
+    /// - The given [`Resource`] is removed from the [`World`] before the command is applied.
+    fn insert_reflect_with_registry<T: Resource + AsRef<TypeRegistry>>(
+        &mut self,
+        component: Box<dyn Reflect>,
+    ) -> &mut Self;
+
+    /// Removes from the entity the component with the given type name registered in [`AppTypeRegistry`].
+    ///
+    /// Does nothing if the entity does not have a component of the same type, if [`AppTypeRegistry`]
+    /// does not contain the reflection data for the given component, or if the entity does not exist.
+    ///
+    /// # Note
+    ///
+    /// Prefer to use the typed [`EntityCommands::remove`] if possible. Removing a reflected component
+    /// is much slower.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// // Note that you need to register the component type in the AppTypeRegistry prior to using
+    /// // reflection. You can use the helpers on the App with `app.register_type::<ComponentA>()`
+    /// // or write to the TypeRegistry directly to register all your components
+    ///
+    /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::reflect::ReflectCommandExt;
+    /// # use bevy_reflect::{FromReflect, FromType, Reflect, TypeRegistry};
+    ///
+    /// // A resource that can hold any component that implements reflect as a boxed reflect component
+    /// #[derive(Resource)]
+    /// struct Prefab{
+    ///     entity: Entity,
+    ///     component: Box<dyn Reflect>,
+    /// }
+    /// #[derive(Component, Reflect, Default)]
+    /// #[reflect(Component)]
+    /// struct ComponentA(u32);
+    /// #[derive(Component, Reflect, Default)]
+    /// #[reflect(Component)]
+    /// struct ComponentB(String);
+    ///
+    /// fn remove_reflect_component(
+    ///     mut commands: Commands,
+    ///     prefab: Res<Prefab>
+    ///     ) {
+    ///     // Prefab can hold any boxed reflect component. In this case either
+    ///     // ComponentA or ComponentB. No matter which component is in the resource though,
+    ///     // we can attempt to remove any component of that same type from an entity.
+    ///     commands.entity(prefab.entity)
+    ///         .remove_reflect(prefab.component.type_name().to_owned());
+    /// }
+    ///
+    /// ```
+    fn remove_reflect(&mut self, component_type_name: impl Into<Cow<'static, str>>) -> &mut Self;
+    /// Same as [`remove_reflect`](ReflectCommandExt::remove_reflect), but using the `T` resource as type registry instead of
+    /// `AppTypeRegistry`.
+    fn remove_reflect_with_registry<T: Resource + AsRef<TypeRegistry>>(
+        &mut self,
+        component_type_name: impl Into<Cow<'static, str>>,
+    ) -> &mut Self;
+}
+
+impl<'w, 's, 'a> ReflectCommandExt for EntityCommands<'w, 's, 'a> {
+    fn insert_reflect(&mut self, component: Box<dyn Reflect>) -> &mut Self {
+        self.commands.add(InsertReflect {
+            entity: self.entity,
+            component,
+        });
+        self
+    }
+
+    fn insert_reflect_with_registry<T: Resource + AsRef<TypeRegistry>>(
+        &mut self,
+        component: Box<dyn Reflect>,
+    ) -> &mut Self {
+        self.commands.add(InsertReflectWithRegistry::<T> {
+            entity: self.entity,
+            _t: PhantomData,
+            component,
+        });
+        self
+    }
+
+    fn remove_reflect(&mut self, component_type_name: impl Into<Cow<'static, str>>) -> &mut Self {
+        self.commands.add(RemoveReflect {
+            entity: self.entity,
+            component_type_name: component_type_name.into(),
+        });
+        self
+    }
+
+    fn remove_reflect_with_registry<T: Resource + AsRef<TypeRegistry>>(
+        &mut self,
+        component_type_name: impl Into<Cow<'static, str>>,
+    ) -> &mut Self {
+        self.commands.add(RemoveReflectWithRegistry::<T> {
+            entity: self.entity,
+            _t: PhantomData,
+            component_type_name: component_type_name.into(),
+        });
+        self
+    }
+}
+
+/// Helper function to add a reflect component to a given entity
+fn insert_reflect(
+    world: &mut World,
+    entity: Entity,
+    type_registry: &TypeRegistry,
+    component: Box<dyn Reflect>,
+) {
+    let type_info = component.type_name();
+    let Some(mut entity) = world.get_entity_mut(entity) else {
+        panic!("error[B0003]: Could not insert a reflected component (of type {}) for entity {entity:?} because it doesn't exist in this World.", component.type_name());
+    };
+    let Some(type_registration) = type_registry.get_with_name(type_info) else {
+        panic!("Could not get type registration (for component type {}) because it doesn't exist in the TypeRegistry.", component.type_name());
+    };
+    let Some(reflect_component) = type_registration.data::<ReflectComponent>() else {
+        panic!("Could not get ReflectComponent data (for component type {}) because it doesn't exist in this TypeRegistration.", component.type_name());
+    };
+    reflect_component.insert(&mut entity, &*component);
+}
+
+/// A [`Command`] that adds the boxed reflect component to an entity using the data in
+/// [`AppTypeRegistry`].
+///
+/// See [`ReflectCommandExt::insert_reflect`] for details.
+pub struct InsertReflect {
+    /// The entity on which the component will be inserted.
+    pub entity: Entity,
+    /// The reflect [Component](crate::component::Component) that will be added to the entity.
+    pub component: Box<dyn Reflect>,
+}
+
+impl Command for InsertReflect {
+    fn apply(self, world: &mut World) {
+        let registry = world.get_resource::<AppTypeRegistry>().unwrap().clone();
+        insert_reflect(world, self.entity, &registry.read(), self.component);
+    }
+}
+
+/// A [`Command`] that adds the boxed reflect component to an entity using the data in the provided
+/// [`Resource`] that implements [`AsRef<TypeRegistry>`].
+///
+/// See [`ReflectCommandExt::insert_reflect_with_registry`] for details.
+pub struct InsertReflectWithRegistry<T: Resource + AsRef<TypeRegistry>> {
+    /// The entity on which the component will be inserted.
+    pub entity: Entity,
+    pub _t: PhantomData<T>,
+    /// The reflect [Component](crate::component::Component) that will be added to the entity.
+    pub component: Box<dyn Reflect>,
+}
+
+impl<T: Resource + AsRef<TypeRegistry>> Command for InsertReflectWithRegistry<T> {
+    fn apply(self, world: &mut World) {
+        world.resource_scope(|world, registry: Mut<T>| {
+            let registry: &TypeRegistry = registry.as_ref().as_ref();
+            insert_reflect(world, self.entity, registry, self.component);
+        });
+    }
+}
+
+/// Helper function to remove a reflect component from a given entity
+fn remove_reflect(
+    world: &mut World,
+    entity: Entity,
+    type_registry: &TypeRegistry,
+    component_type_name: Cow<'static, str>,
+) {
+    let Some(mut entity) = world.get_entity_mut(entity) else {
+        return;
+    };
+    let Some(type_registration) = type_registry.get_with_name(&component_type_name) else {
+        return;
+    };
+    let Some(reflect_component) = type_registration.data::<ReflectComponent>() else {
+        return;
+    };
+    reflect_component.remove(&mut entity);
+}
+
+/// A [`Command`] that removes the component of the same type as the given component type name from
+/// the provided entity.
+///
+/// See [`ReflectCommandExt::remove_reflect`] for details.
+pub struct RemoveReflect {
+    /// The entity from which the component will be removed.
+    pub entity: Entity,
+    /// The [Component](crate::component::Component) type name that will be used to remove a component
+    /// of the same type from the entity.
+    pub component_type_name: Cow<'static, str>,
+}
+
+impl Command for RemoveReflect {
+    fn apply(self, world: &mut World) {
+        let registry = world.get_resource::<AppTypeRegistry>().unwrap().clone();
+        remove_reflect(
+            world,
+            self.entity,
+            &registry.read(),
+            self.component_type_name,
+        );
+    }
+}
+
+/// A [`Command`] that removes the component of the same type as the given component type name from
+/// the provided entity using the provided [`Resource`] that implements [`AsRef<TypeRegistry>`].
+///
+/// See [`ReflectCommandExt::remove_reflect_with_registry`] for details.
+pub struct RemoveReflectWithRegistry<T: Resource + AsRef<TypeRegistry>> {
+    /// The entity from which the component will be removed.
+    pub entity: Entity,
+    pub _t: PhantomData<T>,
+    /// The [Component](crate::component::Component) type name that will be used to remove a component
+    /// of the same type from the entity.
+    pub component_type_name: Cow<'static, str>,
+}
+
+impl<T: Resource + AsRef<TypeRegistry>> Command for RemoveReflectWithRegistry<T> {
+    fn apply(self, world: &mut World) {
+        world.resource_scope(|world, registry: Mut<T>| {
+            let registry: &TypeRegistry = registry.as_ref().as_ref();
+            remove_reflect(world, self.entity, registry, self.component_type_name);
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::{AppTypeRegistry, ReflectComponent};
+    use crate::reflect::ReflectCommandExt;
+    use crate::system::{Commands, SystemState};
+    use crate::{self as bevy_ecs, component::Component, world::World};
+    use bevy_ecs_macros::Resource;
+    use bevy_reflect::{Reflect, TypeRegistry};
+
+    #[derive(Resource)]
+    struct TypeRegistryResource {
+        type_registry: TypeRegistry,
+    }
+
+    impl AsRef<TypeRegistry> for TypeRegistryResource {
+        fn as_ref(&self) -> &TypeRegistry {
+            &self.type_registry
+        }
+    }
+
+    #[derive(Component, Reflect, Default, PartialEq, Eq, Debug)]
+    #[reflect(Component)]
+    struct ComponentA(u32);
+
+    #[test]
+    fn insert_reflected() {
+        let mut world = World::new();
+
+        let type_registry = AppTypeRegistry::default();
+        {
+            let mut registry = type_registry.write();
+            registry.register::<ComponentA>();
+            registry.register_type_data::<ComponentA, ReflectComponent>();
+        }
+        world.insert_resource(type_registry);
+
+        let mut system_state: SystemState<Commands> = SystemState::new(&mut world);
+        let mut commands = system_state.get_mut(&mut world);
+
+        let entity = commands.spawn_empty().id();
+
+        let boxed_reflect_component_a = Box::new(ComponentA(916)) as Box<dyn Reflect>;
+
+        commands
+            .entity(entity)
+            .insert_reflect(boxed_reflect_component_a);
+        system_state.apply(&mut world);
+
+        assert_eq!(
+            world.entity(entity).get::<ComponentA>(),
+            Some(&ComponentA(916))
+        );
+    }
+
+    #[test]
+    fn insert_reflected_with_registry() {
+        let mut world = World::new();
+
+        let mut type_registry = TypeRegistryResource {
+            type_registry: TypeRegistry::new(),
+        };
+
+        type_registry.type_registry.register::<ComponentA>();
+        type_registry
+            .type_registry
+            .register_type_data::<ComponentA, ReflectComponent>();
+        world.insert_resource(type_registry);
+
+        let mut system_state: SystemState<Commands> = SystemState::new(&mut world);
+        let mut commands = system_state.get_mut(&mut world);
+
+        let entity = commands.spawn_empty().id();
+
+        let boxed_reflect_component_a = Box::new(ComponentA(916)) as Box<dyn Reflect>;
+
+        commands
+            .entity(entity)
+            .insert_reflect_with_registry::<TypeRegistryResource>(boxed_reflect_component_a);
+        system_state.apply(&mut world);
+
+        assert_eq!(
+            world.entity(entity).get::<ComponentA>(),
+            Some(&ComponentA(916))
+        );
+    }
+
+    #[test]
+    fn remove_reflected() {
+        let mut world = World::new();
+
+        let type_registry = AppTypeRegistry::default();
+        {
+            let mut registry = type_registry.write();
+            registry.register::<ComponentA>();
+            registry.register_type_data::<ComponentA, ReflectComponent>();
+        }
+        world.insert_resource(type_registry);
+
+        let mut system_state: SystemState<Commands> = SystemState::new(&mut world);
+        let mut commands = system_state.get_mut(&mut world);
+
+        let entity = commands.spawn(ComponentA(0)).id();
+
+        let boxed_reflect_component_a = Box::new(ComponentA(916)) as Box<dyn Reflect>;
+
+        commands
+            .entity(entity)
+            .remove_reflect(boxed_reflect_component_a.type_name().to_owned());
+        system_state.apply(&mut world);
+
+        assert_eq!(world.entity(entity).get::<ComponentA>(), None);
+    }
+
+    #[test]
+    fn remove_reflected_with_registry() {
+        let mut world = World::new();
+
+        let mut type_registry = TypeRegistryResource {
+            type_registry: TypeRegistry::new(),
+        };
+
+        type_registry.type_registry.register::<ComponentA>();
+        type_registry
+            .type_registry
+            .register_type_data::<ComponentA, ReflectComponent>();
+        world.insert_resource(type_registry);
+
+        let mut system_state: SystemState<Commands> = SystemState::new(&mut world);
+        let mut commands = system_state.get_mut(&mut world);
+
+        let entity = commands.spawn(ComponentA(0)).id();
+
+        let boxed_reflect_component_a = Box::new(ComponentA(916)) as Box<dyn Reflect>;
+
+        commands
+            .entity(entity)
+            .remove_reflect_with_registry::<TypeRegistryResource>(
+                boxed_reflect_component_a.type_name().to_owned(),
+            );
+        system_state.apply(&mut world);
+
+        assert_eq!(world.entity(entity).get::<ComponentA>(), None);
+    }
+}

--- a/crates/bevy_ecs/src/reflect/map_entities.rs
+++ b/crates/bevy_ecs/src/reflect/map_entities.rs
@@ -1,9 +1,10 @@
 use crate::{
     component::Component,
-    entity::{Entity, EntityMap, EntityMapper, MapEntities},
+    entity::{Entity, EntityMapper, MapEntities},
     world::World,
 };
 use bevy_reflect::FromType;
+use bevy_utils::HashMap;
 
 /// For a specific type of component, this maps any fields with values of type [`Entity`] to a new world.
 /// Since a given `Entity` ID is only valid for the world it came from, when performing deserialization
@@ -17,27 +18,32 @@ pub struct ReflectMapEntities {
 }
 
 impl ReflectMapEntities {
-    /// A general method for applying [`MapEntities`] behavior to all elements in an [`EntityMap`].
+    /// A general method for applying [`MapEntities`] behavior to all elements in an [`HashMap<Entity, Entity>`].
     ///
-    /// Be mindful in its usage: Works best in situations where the entities in the [`EntityMap`] are newly
+    /// Be mindful in its usage: Works best in situations where the entities in the [`HashMap<Entity, Entity>`] are newly
     /// created, before systems have a chance to add new components. If some of the entities referred to
-    /// by the [`EntityMap`] might already contain valid entity references, you should use [`map_entities`](Self::map_entities).
+    /// by the [`HashMap<Entity, Entity>`] might already contain valid entity references, you should use [`map_entities`](Self::map_entities).
     ///
     /// An example of this: A scene can be loaded with `Parent` components, but then a `Parent` component can be added
     /// to these entities after they have been loaded. If you reload the scene using [`map_all_entities`](Self::map_all_entities), those `Parent`
     /// components with already valid entity references could be updated to point at something else entirely.
-    pub fn map_all_entities(&self, world: &mut World, entity_map: &mut EntityMap) {
-        entity_map.world_scope(world, self.map_all_entities);
+    pub fn map_all_entities(&self, world: &mut World, entity_map: &mut HashMap<Entity, Entity>) {
+        EntityMapper::world_scope(entity_map, world, self.map_all_entities);
     }
 
-    /// A general method for applying [`MapEntities`] behavior to elements in an [`EntityMap`]. Unlike
+    /// A general method for applying [`MapEntities`] behavior to elements in an [`HashMap<Entity, Entity>`]. Unlike
     /// [`map_all_entities`](Self::map_all_entities), this is applied to specific entities, not all values
-    /// in the [`EntityMap`].
+    /// in the [`HashMap<Entity, Entity>`].
     ///
     /// This is useful mostly for when you need to be careful not to update components that already contain valid entity
     /// values. See [`map_all_entities`](Self::map_all_entities) for more details.
-    pub fn map_entities(&self, world: &mut World, entity_map: &mut EntityMap, entities: &[Entity]) {
-        entity_map.world_scope(world, |world, mapper| {
+    pub fn map_entities(
+        &self,
+        world: &mut World,
+        entity_map: &mut HashMap<Entity, Entity>,
+        entities: &[Entity],
+    ) {
+        EntityMapper::world_scope(entity_map, world, |world, mapper| {
             (self.map_entities)(world, mapper, entities);
         });
     }
@@ -54,7 +60,11 @@ impl<C: Component + MapEntities> FromType<C> for ReflectMapEntities {
                 }
             },
             map_all_entities: |world, entity_mapper| {
-                let entities = entity_mapper.get_map().values().collect::<Vec<Entity>>();
+                let entities = entity_mapper
+                    .get_map()
+                    .values()
+                    .copied()
+                    .collect::<Vec<Entity>>();
                 for entity in &entities {
                     if let Some(mut component) = world.get_mut::<C>(*entity) {
                         component.map_entities(entity_mapper);

--- a/crates/bevy_ecs/src/reflect/mod.rs
+++ b/crates/bevy_ecs/src/reflect/mod.rs
@@ -8,11 +8,13 @@ use bevy_reflect::{impl_reflect_value, ReflectDeserialize, ReflectSerialize, Typ
 
 mod bundle;
 mod component;
+mod entity_commands;
 mod map_entities;
 mod resource;
 
 pub use bundle::{ReflectBundle, ReflectBundleFns};
 pub use component::{ReflectComponent, ReflectComponentFns};
+pub use entity_commands::ReflectCommandExt;
 pub use map_entities::ReflectMapEntities;
 pub use resource::{ReflectResource, ReflectResourceFns};
 

--- a/crates/bevy_ecs/src/reflect/mod.rs
+++ b/crates/bevy_ecs/src/reflect/mod.rs
@@ -6,10 +6,12 @@ use crate as bevy_ecs;
 use crate::{entity::Entity, system::Resource};
 use bevy_reflect::{impl_reflect_value, ReflectDeserialize, ReflectSerialize, TypeRegistryArc};
 
+mod bundle;
 mod component;
 mod map_entities;
 mod resource;
 
+pub use bundle::{ReflectBundle, ReflectBundleFns};
 pub use component::{ReflectComponent, ReflectComponentFns};
 pub use map_entities::ReflectMapEntities;
 pub use resource::{ReflectResource, ReflectResourceFns};

--- a/crates/bevy_ecs/src/removal_detection.rs
+++ b/crates/bevy_ecs/src/removal_detection.rs
@@ -4,9 +4,7 @@ use crate::{
     self as bevy_ecs,
     component::{Component, ComponentId, ComponentIdFor, Tick},
     entity::Entity,
-    event::{
-        Event, EventId, Events, ManualEventIterator, ManualEventIteratorWithId, ManualEventReader,
-    },
+    event::{Event, EventId, EventIterator, EventIteratorWithId, Events, ManualEventReader},
     prelude::Local,
     storage::SparseSet,
     system::{ReadOnlySystemParam, SystemMeta, SystemParam},
@@ -145,7 +143,7 @@ pub struct RemovedComponents<'w, 's, T: Component> {
 ///
 /// See [`RemovedComponents`].
 pub type RemovedIter<'a> = iter::Map<
-    iter::Flatten<option::IntoIter<iter::Cloned<ManualEventIterator<'a, RemovedComponentEntity>>>>,
+    iter::Flatten<option::IntoIter<iter::Cloned<EventIterator<'a, RemovedComponentEntity>>>>,
     fn(RemovedComponentEntity) -> Entity,
 >;
 
@@ -153,7 +151,7 @@ pub type RemovedIter<'a> = iter::Map<
 ///
 /// See [`RemovedComponents`].
 pub type RemovedIterWithId<'a> = iter::Map<
-    iter::Flatten<option::IntoIter<ManualEventIteratorWithId<'a, RemovedComponentEntity>>>,
+    iter::Flatten<option::IntoIter<EventIteratorWithId<'a, RemovedComponentEntity>>>,
     fn(
         (&RemovedComponentEntity, EventId<RemovedComponentEntity>),
     ) -> (Entity, EventId<RemovedComponentEntity>),

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -26,7 +26,7 @@ pub type BoxedCondition<In = ()> = Box<dyn ReadOnlySystem<In = In, Out = bool>>;
 ///
 /// # #[derive(Resource)] struct DidRun(bool);
 /// # fn my_system(mut did_run: ResMut<DidRun>) { did_run.0 = true; }
-/// # let mut schedule = Schedule::new();
+/// # let mut schedule = Schedule::default();
 /// schedule.add_systems(my_system.run_if(every_other_time()));
 /// # let mut world = World::new();
 /// # world.insert_resource(DidRun(false));
@@ -46,13 +46,13 @@ pub type BoxedCondition<In = ()> = Box<dyn ReadOnlySystem<In = In, Out = bool>>;
 /// }
 ///
 /// # fn always_true() -> bool { true }
-/// # let mut schedule = Schedule::new();
+/// # let mut app = Schedule::default();
 /// # #[derive(Resource)] struct DidRun(bool);
 /// # fn my_system(mut did_run: ResMut<DidRun>) { did_run.0 = true; }
-/// schedule.add_systems(my_system.run_if(always_true.pipe(identity())));
+/// app.add_systems(my_system.run_if(always_true.pipe(identity())));
 /// # let mut world = World::new();
 /// # world.insert_resource(DidRun(false));
-/// # schedule.run(&mut world);
+/// # app.run(&mut world);
 /// # assert!(world.resource::<DidRun>().0);
 pub trait Condition<Marker, In = ()>: sealed::Condition<Marker, In> {
     /// Returns a new run condition that only returns `true`
@@ -69,7 +69,7 @@ pub trait Condition<Marker, In = ()>: sealed::Condition<Marker, In> {
     /// #[derive(Resource, PartialEq)]
     /// struct R(u32);
     ///
-    /// # let mut app = Schedule::new();
+    /// # let mut app = Schedule::default();
     /// # let mut world = World::new();
     /// # fn my_system() {}
     /// app.add_systems(
@@ -86,7 +86,7 @@ pub trait Condition<Marker, In = ()>: sealed::Condition<Marker, In> {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, PartialEq)]
     /// # struct R(u32);
-    /// # let mut app = Schedule::new();
+    /// # let mut app = Schedule::default();
     /// # let mut world = World::new();
     /// # fn my_system() {}
     /// app.add_systems(
@@ -123,7 +123,7 @@ pub trait Condition<Marker, In = ()>: sealed::Condition<Marker, In> {
     /// #[derive(Resource, PartialEq)]
     /// struct B(u32);
     ///
-    /// # let mut app = Schedule::new();
+    /// # let mut app = Schedule::default();
     /// # let mut world = World::new();
     /// # #[derive(Resource)] struct C(bool);
     /// # fn my_system(mut c: ResMut<C>) { c.0 = true; }
@@ -197,7 +197,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::new();
+    /// # let mut app = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// app.add_systems(
@@ -238,7 +238,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::new();
+    /// # let mut app = Schedule::default();
     /// # let mut world = World::new();
     /// app.add_systems(
     ///     // `resource_exists` will only return true if the given resource exists in the world
@@ -277,7 +277,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default, PartialEq)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::new();
+    /// # let mut app = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// app.add_systems(
@@ -315,7 +315,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default, PartialEq)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::new();
+    /// # let mut app = Schedule::default();
     /// # let mut world = World::new();
     /// app.add_systems(
     ///     // `resource_exists_and_equals` will only return true
@@ -358,7 +358,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::new();
+    /// # let mut app = Schedule::default();
     /// # let mut world = World::new();
     /// app.add_systems(
     ///     // `resource_added` will only return true if the
@@ -408,7 +408,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::new();
+    /// # let mut app = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// app.add_systems(
@@ -462,7 +462,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::new();
+    /// # let mut app = Schedule::default();
     /// # let mut world = World::new();
     /// app.add_systems(
     ///     // `resource_exists_and_changed` will only return true if the
@@ -523,7 +523,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::new();
+    /// # let mut app = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// app.add_systems(
@@ -593,7 +593,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::new();
+    /// # let mut app = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// app.add_systems(
@@ -648,7 +648,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::new();
+    /// # let mut app = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// #[derive(States, Clone, Copy, Default, Eq, PartialEq, Hash, Debug)]
@@ -695,7 +695,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::new();
+    /// # let mut app = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// #[derive(States, Clone, Copy, Default, Eq, PartialEq, Hash, Debug)]
@@ -747,7 +747,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::new();
+    /// # let mut app = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// #[derive(States, Clone, Copy, Default, Eq, PartialEq, Hash, Debug)]
@@ -813,7 +813,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::new();
+    /// # let mut app = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// #[derive(States, Clone, Copy, Default, Eq, PartialEq, Hash, Debug)]
@@ -863,7 +863,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::new();
+    /// # let mut app = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// # world.init_resource::<Events<MyEvent>>();
@@ -907,7 +907,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::new();
+    /// # let mut app = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// app.add_systems(
@@ -954,7 +954,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::new();
+    /// # let mut app = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// app.add_systems(
@@ -1067,7 +1067,7 @@ mod tests {
     use crate::{change_detection::ResMut, schedule::Schedule, world::World};
     use bevy_ecs_macros::Event;
     use bevy_ecs_macros::Resource;
-    
+
     #[derive(Resource, Default)]
     struct Counter(usize);
 

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -1067,7 +1067,7 @@ mod tests {
     use crate::{change_detection::ResMut, schedule::Schedule, world::World};
     use bevy_ecs_macros::Event;
     use bevy_ecs_macros::Resource;
-
+    
     #[derive(Resource, Default)]
     struct Counter(usize);
 
@@ -1084,7 +1084,7 @@ mod tests {
     fn run_condition() {
         let mut world = World::new();
         world.init_resource::<Counter>();
-        let mut schedule = Schedule::new();
+        let mut schedule = Schedule::default();
 
         // Run every other cycle
         schedule.add_systems(increment_counter.run_if(every_other_time));
@@ -1111,7 +1111,7 @@ mod tests {
     fn run_condition_combinators() {
         let mut world = World::new();
         world.init_resource::<Counter>();
-        let mut schedule = Schedule::new();
+        let mut schedule = Schedule::default();
 
         // Always run
         schedule.add_systems(increment_counter.run_if(every_other_time.or_else(|| true)));
@@ -1128,7 +1128,7 @@ mod tests {
     fn multiple_run_conditions() {
         let mut world = World::new();
         world.init_resource::<Counter>();
-        let mut schedule = Schedule::new();
+        let mut schedule = Schedule::default();
 
         // Run every other cycle
         schedule.add_systems(increment_counter.run_if(every_other_time).run_if(|| true));
@@ -1146,7 +1146,7 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Counter>();
 
-        let mut schedule = Schedule::new();
+        let mut schedule = Schedule::default();
 
         // This should never run, if multiple run conditions worked
         // like an OR condition then it would always run

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -225,7 +225,7 @@ where
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # let mut schedule = Schedule::new();
+    /// # let mut schedule = Schedule::default();
     /// # fn a() {}
     /// # fn b() {}
     /// # fn condition() -> bool { true }
@@ -258,7 +258,7 @@ where
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # let mut schedule = Schedule::new();
+    /// # let mut schedule = Schedule::default();
     /// # fn a() {}
     /// # fn b() {}
     /// # fn condition() -> bool { true }

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -393,6 +393,7 @@ pub struct SystemSetConfig {
 }
 
 impl SystemSetConfig {
+    #[track_caller]
     fn new(set: BoxedSystemSet) -> Self {
         // system type sets are automatically populated
         // to avoid unintentionally broad changes, they cannot be configured
@@ -449,6 +450,7 @@ pub trait IntoSystemSetConfig: Sized {
 }
 
 impl<S: SystemSet> IntoSystemSetConfig for S {
+    #[track_caller]
     fn into_config(self) -> SystemSetConfig {
         SystemSetConfig::new(Box::new(self))
     }

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -83,14 +83,15 @@ impl SystemConfigs {
         })
     }
 
-    pub(crate) fn in_set_inner(&mut self, set: BoxedSystemSet) {
+    /// Adds a new boxed system set to the systems.
+    pub fn in_set_dyn(&mut self, set: BoxedSystemSet) {
         match self {
             SystemConfigs::SystemConfig(config) => {
                 config.graph_info.sets.push(set);
             }
             SystemConfigs::Configs { configs, .. } => {
                 for config in configs {
-                    config.in_set_inner(set.dyn_clone());
+                    config.in_set_dyn(set.dyn_clone());
                 }
             }
         }
@@ -167,7 +168,11 @@ impl SystemConfigs {
         }
     }
 
-    pub(crate) fn run_if_inner(&mut self, condition: BoxedCondition) {
+    /// Adds a new boxed run condition to the systems.
+    ///
+    /// This is useful if you have a run condition whose concrete type is unknown.
+    /// Prefer `run_if` for run conditions whose type is known at compile time.
+    pub fn run_if_dyn(&mut self, condition: BoxedCondition) {
         match self {
             SystemConfigs::SystemConfig(config) => {
                 config.conditions.push(condition);
@@ -307,7 +312,7 @@ impl IntoSystemConfigs<()> for SystemConfigs {
             "adding arbitrary systems to a system type set is not allowed"
         );
 
-        self.in_set_inner(set.dyn_clone());
+        self.in_set_dyn(set.dyn_clone());
 
         self
     }
@@ -341,7 +346,7 @@ impl IntoSystemConfigs<()> for SystemConfigs {
     }
 
     fn run_if<M>(mut self, condition: impl Condition<M>) -> SystemConfigs {
-        self.run_if_inner(new_condition(condition));
+        self.run_if_dyn(new_condition(condition));
         self
     }
 

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -70,7 +70,6 @@ mod tests {
     mod system_execution {
         use super::*;
 
-
         #[test]
         fn run_system() {
             let mut world = World::default();

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -541,7 +541,10 @@ mod tests {
             schedule.configure_set(TestSet::B.after(TestSet::A));
 
             let result = schedule.initialize(&mut world);
-            assert!(matches!(result, Err(ScheduleBuildError::DependencyCycle)));
+            assert!(matches!(
+                result,
+                Err(ScheduleBuildError::DependencyCycle(_))
+            ));
 
             fn foo() {}
             fn bar() {}
@@ -551,7 +554,10 @@ mod tests {
 
             schedule.add_systems((foo.after(bar), bar.after(foo)));
             let result = schedule.initialize(&mut world);
-            assert!(matches!(result, Err(ScheduleBuildError::DependencyCycle)));
+            assert!(matches!(
+                result,
+                Err(ScheduleBuildError::DependencyCycle(_))
+            ));
         }
 
         #[test]
@@ -570,7 +576,7 @@ mod tests {
             schedule.configure_set(TestSet::B.in_set(TestSet::A));
 
             let result = schedule.initialize(&mut world);
-            assert!(matches!(result, Err(ScheduleBuildError::HierarchyCycle)));
+            assert!(matches!(result, Err(ScheduleBuildError::HierarchyCycle(_))));
         }
 
         #[test]
@@ -645,7 +651,7 @@ mod tests {
             let result = schedule.initialize(&mut world);
             assert!(matches!(
                 result,
-                Err(ScheduleBuildError::HierarchyRedundancy)
+                Err(ScheduleBuildError::HierarchyRedundancy(_))
             ));
         }
 
@@ -707,7 +713,7 @@ mod tests {
 
             schedule.add_systems((res_ref, res_mut));
             let result = schedule.initialize(&mut world);
-            assert!(matches!(result, Err(ScheduleBuildError::Ambiguity)));
+            assert!(matches!(result, Err(ScheduleBuildError::Ambiguity(_))));
         }
     }
 }

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -70,6 +70,7 @@ mod tests {
     mod system_execution {
         use super::*;
 
+
         #[test]
         fn run_system() {
             let mut world = World::default();
@@ -180,7 +181,7 @@ mod tests {
         #[test]
         fn add_systems_correct_order() {
             let mut world = World::new();
-            let mut schedule = Schedule::new();
+            let mut schedule = Schedule::default();
 
             world.init_resource::<SystemOrder>();
 
@@ -201,7 +202,7 @@ mod tests {
         #[test]
         fn add_systems_correct_order_nested() {
             let mut world = World::new();
-            let mut schedule = Schedule::new();
+            let mut schedule = Schedule::default();
 
             world.init_resource::<SystemOrder>();
 
@@ -528,14 +529,14 @@ mod tests {
         #[test]
         #[should_panic]
         fn dependency_loop() {
-            let mut schedule = Schedule::new();
+            let mut schedule = Schedule::default();
             schedule.configure_set(TestSet::X.after(TestSet::X));
         }
 
         #[test]
         fn dependency_cycle() {
             let mut world = World::new();
-            let mut schedule = Schedule::new();
+            let mut schedule = Schedule::default();
 
             schedule.configure_set(TestSet::A.after(TestSet::B));
             schedule.configure_set(TestSet::B.after(TestSet::A));
@@ -550,7 +551,7 @@ mod tests {
             fn bar() {}
 
             let mut world = World::new();
-            let mut schedule = Schedule::new();
+            let mut schedule = Schedule::default();
 
             schedule.add_systems((foo.after(bar), bar.after(foo)));
             let result = schedule.initialize(&mut world);
@@ -563,14 +564,14 @@ mod tests {
         #[test]
         #[should_panic]
         fn hierarchy_loop() {
-            let mut schedule = Schedule::new();
+            let mut schedule = Schedule::default();
             schedule.configure_set(TestSet::X.in_set(TestSet::X));
         }
 
         #[test]
         fn hierarchy_cycle() {
             let mut world = World::new();
-            let mut schedule = Schedule::new();
+            let mut schedule = Schedule::default();
 
             schedule.configure_set(TestSet::A.in_set(TestSet::B));
             schedule.configure_set(TestSet::B.in_set(TestSet::A));
@@ -586,7 +587,7 @@ mod tests {
             fn bar() {}
 
             let mut world = World::new();
-            let mut schedule = Schedule::new();
+            let mut schedule = Schedule::default();
 
             // Schedule `bar` to run after `foo`.
             schedule.add_systems((foo, bar.after(foo)));
@@ -607,7 +608,7 @@ mod tests {
             ));
 
             // same goes for `ambiguous_with`
-            let mut schedule = Schedule::new();
+            let mut schedule = Schedule::default();
             schedule.add_systems(foo);
             schedule.add_systems(bar.ambiguous_with(foo));
             let result = schedule.initialize(&mut world);
@@ -624,14 +625,14 @@ mod tests {
         #[should_panic]
         fn configure_system_type_set() {
             fn foo() {}
-            let mut schedule = Schedule::new();
+            let mut schedule = Schedule::default();
             schedule.configure_set(foo.into_system_set());
         }
 
         #[test]
         fn hierarchy_redundancy() {
             let mut world = World::new();
-            let mut schedule = Schedule::new();
+            let mut schedule = Schedule::default();
 
             schedule.set_build_settings(ScheduleBuildSettings {
                 hierarchy_detection: LogLevel::Error,
@@ -658,7 +659,7 @@ mod tests {
         #[test]
         fn cross_dependency() {
             let mut world = World::new();
-            let mut schedule = Schedule::new();
+            let mut schedule = Schedule::default();
 
             // Add `B` and give it both kinds of relationships with `A`.
             schedule.configure_set(TestSet::B.in_set(TestSet::A));
@@ -673,7 +674,7 @@ mod tests {
         #[test]
         fn sets_have_order_but_intersect() {
             let mut world = World::new();
-            let mut schedule = Schedule::new();
+            let mut schedule = Schedule::default();
 
             fn foo() {}
 
@@ -704,7 +705,7 @@ mod tests {
             fn res_mut(_x: ResMut<X>) {}
 
             let mut world = World::new();
-            let mut schedule = Schedule::new();
+            let mut schedule = Schedule::default();
 
             schedule.set_build_settings(ScheduleBuildSettings {
                 ambiguity_detection: LogLevel::Error,

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -250,7 +250,7 @@ impl Schedule {
         let _span = bevy_utils::tracing::info_span!("schedule", name = ?self.name).entered();
 
         world.check_change_ticks();
-        self.initialize(world).unwrap_or_else(|e| panic!("{e}"));
+        self.initialize(world).unwrap_or_else(|e| panic!("Error when intializing schedule {:?}: {e}", self.name));
         self.executor.run(&mut self.executable, world);
     }
 

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -169,8 +169,9 @@ pub struct Schedule {
 struct DefaultSchedule;
 
 /// Creates a schedule with a default label. Only use in situations where
-/// you want a standalone schedule. If you're inserting the schedule into the world
-/// use [`Schedule::new`] instead.
+/// where you don't care about the [`ScheduleLabel`]. Inserting a default schedule
+/// into the world risks overwriting another schedule. For most situations you should use
+/// [`Schedule::new`].
 impl Default for Schedule {
     fn default() -> Self {
         Self::new(DefaultSchedule)

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -165,7 +165,6 @@ pub struct Schedule {
     executor_initialized: bool,
 }
 
-
 #[derive(ScheduleLabel, Hash, PartialEq, Eq, Debug, Clone)]
 struct DefaultSchedule;
 
@@ -184,7 +183,7 @@ impl Schedule {
         Self {
             name: label.dyn_clone(),
             graph: ScheduleGraph::new(),
-            executable: SystemSchedule::new(),
+            executable: SystemSchedule::default(),
             executor: make_executor(ExecutorKind::default()),
             executor_initialized: false,
         }
@@ -246,6 +245,9 @@ impl Schedule {
 
     /// Runs all systems in this schedule on the `world`, using its current execution strategy.
     pub fn run(&mut self, world: &mut World) {
+        #[cfg(feature = "trace")]
+        let _span = bevy_utils::tracing::info_span!("schedule", name = ?self.name).entered();
+
         world.check_change_ticks();
         self.initialize(world).unwrap_or_else(|e| panic!("{e}"));
         self.executor.run(&mut self.executable, world);

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -382,9 +382,7 @@ pub struct ScheduleGraph {
     uninit: Vec<(NodeId, usize)>,
     hierarchy: Dag,
     dependency: Dag,
-    dependency_flattened: Dag,
     ambiguous_with: UnGraphMap<NodeId, ()>,
-    ambiguous_with_flattened: UnGraphMap<NodeId, ()>,
     ambiguous_with_all: HashSet<NodeId>,
     conflicting_systems: Vec<(NodeId, NodeId, Vec<ComponentId>)>,
     changed: bool,
@@ -403,9 +401,7 @@ impl ScheduleGraph {
             uninit: Vec::new(),
             hierarchy: Dag::new(),
             dependency: Dag::new(),
-            dependency_flattened: Dag::new(),
             ambiguous_with: UnGraphMap::new(),
-            ambiguous_with_flattened: UnGraphMap::new(),
             ambiguous_with_all: HashSet::new(),
             conflicting_systems: Vec::new(),
             changed: false,
@@ -863,45 +859,70 @@ impl ScheduleGraph {
         components: &Components,
     ) -> Result<SystemSchedule, ScheduleBuildError> {
         // check hierarchy for cycles
-        self.hierarchy.topsort = self
-            .topsort_graph(&self.hierarchy.graph, ReportCycles::Hierarchy)
-            .map_err(|_| ScheduleBuildError::HierarchyCycle)?;
+        self.hierarchy.topsort =
+            self.topsort_graph(&self.hierarchy.graph, ReportCycles::Hierarchy)?;
 
         let hier_results = check_graph(&self.hierarchy.graph, &self.hierarchy.topsort);
-        if self.settings.hierarchy_detection != LogLevel::Ignore
-            && self.contains_hierarchy_conflicts(&hier_results.transitive_edges)
-        {
-            self.report_hierarchy_conflicts(&hier_results.transitive_edges);
-            if matches!(self.settings.hierarchy_detection, LogLevel::Error) {
-                return Err(ScheduleBuildError::HierarchyRedundancy);
-            }
-        }
+        self.optionally_check_hierarchy_conflicts(&hier_results.transitive_edges)?;
 
         // remove redundant edges
         self.hierarchy.graph = hier_results.transitive_reduction;
 
         // check dependencies for cycles
-        self.dependency.topsort = self
-            .topsort_graph(&self.dependency.graph, ReportCycles::Dependency)
-            .map_err(|_| ScheduleBuildError::DependencyCycle)?;
+        self.dependency.topsort =
+            self.topsort_graph(&self.dependency.graph, ReportCycles::Dependency)?;
 
         // check for systems or system sets depending on sets they belong to
         let dep_results = check_graph(&self.dependency.graph, &self.dependency.topsort);
-        for &(a, b) in dep_results.connected.iter() {
-            if hier_results.connected.contains(&(a, b)) || hier_results.connected.contains(&(b, a))
-            {
-                let name_a = self.get_node_name(&a);
-                let name_b = self.get_node_name(&b);
-                return Err(ScheduleBuildError::CrossDependency(name_a, name_b));
-            }
-        }
+        self.check_for_cross_dependencies(&dep_results, &hier_results.connected)?;
 
         // map all system sets to their systems
         // go in reverse topological order (bottom-up) for efficiency
+        let (set_systems, set_system_bitsets) =
+            self.map_sets_to_systems(&self.hierarchy.topsort, &self.hierarchy.graph);
+        self.check_order_but_intersect(&dep_results.connected, &set_system_bitsets)?;
+
+        // check that there are no edges to system-type sets that have multiple instances
+        self.check_system_type_set_ambiguity(&set_systems)?;
+
+        let dependency_flattened = self.get_dependency_flattened(&set_systems);
+
+        // topsort
+        let mut dependency_flattened_dag = Dag {
+            topsort: self.topsort_graph(&dependency_flattened, ReportCycles::Dependency)?,
+            graph: dependency_flattened,
+        };
+
+        let flat_results = check_graph(
+            &dependency_flattened_dag.graph,
+            &dependency_flattened_dag.topsort,
+        );
+
+        // remove redundant edges
+        dependency_flattened_dag.graph = flat_results.transitive_reduction;
+
+        // flatten: combine `in_set` with `ambiguous_with` information
+        let ambiguous_with_flattened = self.get_ambiguous_with_flattened(&set_systems);
+
+        // check for conflicts
+        let conflicting_systems =
+            self.get_conflicting_systems(&flat_results.disconnected, &ambiguous_with_flattened);
+        self.optionally_check_conflicts(&conflicting_systems, components)?;
+        self.conflicting_systems = conflicting_systems;
+
+        // build the schedule
+        Ok(self.build_schedule_inner(dependency_flattened_dag, hier_results.reachable))
+    }
+
+    fn map_sets_to_systems(
+        &self,
+        hierarchy_topsort: &[NodeId],
+        hierarchy_graph: &GraphMap<NodeId, (), Directed>,
+    ) -> (HashMap<NodeId, Vec<NodeId>>, HashMap<NodeId, FixedBitSet>) {
         let mut set_systems: HashMap<NodeId, Vec<NodeId>> =
             HashMap::with_capacity(self.system_sets.len());
         let mut set_system_bitsets = HashMap::with_capacity(self.system_sets.len());
-        for &id in self.hierarchy.topsort.iter().rev() {
+        for &id in hierarchy_topsort.iter().rev() {
             if id.is_system() {
                 continue;
             }
@@ -909,11 +930,7 @@ impl ScheduleGraph {
             let mut systems = Vec::new();
             let mut system_bitset = FixedBitSet::with_capacity(self.systems.len());
 
-            for child in self
-                .hierarchy
-                .graph
-                .neighbors_directed(id, Direction::Outgoing)
-            {
+            for child in hierarchy_graph.neighbors_directed(id, Direction::Outgoing) {
                 match child {
                     NodeId::System(_) => {
                         systems.push(child);
@@ -931,47 +948,13 @@ impl ScheduleGraph {
             set_systems.insert(id, systems);
             set_system_bitsets.insert(id, system_bitset);
         }
+        (set_systems, set_system_bitsets)
+    }
 
-        // check that there is no ordering between system sets that intersect
-        for (a, b) in dep_results.connected.iter() {
-            if !(a.is_set() && b.is_set()) {
-                continue;
-            }
-
-            let a_systems = set_system_bitsets.get(a).unwrap();
-            let b_systems = set_system_bitsets.get(b).unwrap();
-
-            if !(a_systems.is_disjoint(b_systems)) {
-                return Err(ScheduleBuildError::SetsHaveOrderButIntersect(
-                    self.get_node_name(a),
-                    self.get_node_name(b),
-                ));
-            }
-        }
-
-        // check that there are no edges to system-type sets that have multiple instances
-        for (&id, systems) in set_systems.iter() {
-            let set = &self.system_sets[id.index()];
-            if set.is_system_type() {
-                let instances = systems.len();
-                let ambiguous_with = self.ambiguous_with.edges(id);
-                let before = self
-                    .dependency
-                    .graph
-                    .edges_directed(id, Direction::Incoming);
-                let after = self
-                    .dependency
-                    .graph
-                    .edges_directed(id, Direction::Outgoing);
-                let relations = before.count() + after.count() + ambiguous_with.count();
-                if instances > 1 && relations > 0 {
-                    return Err(ScheduleBuildError::SystemTypeSetAmbiguity(
-                        self.get_node_name(&id),
-                    ));
-                }
-            }
-        }
-
+    fn get_dependency_flattened(
+        &self,
+        set_systems: &HashMap<NodeId, Vec<NodeId>>,
+    ) -> GraphMap<NodeId, (), Directed> {
         // flatten: combine `in_set` with `before` and `after` information
         // have to do it like this to preserve transitivity
         let mut dependency_flattened = self.dependency.graph.clone();
@@ -1003,21 +986,13 @@ impl ScheduleGraph {
             }
         }
 
-        // topsort
-        self.dependency_flattened.topsort = self
-            .topsort_graph(&dependency_flattened, ReportCycles::Dependency)
-            .map_err(|_| ScheduleBuildError::DependencyCycle)?;
-        self.dependency_flattened.graph = dependency_flattened;
+        dependency_flattened
+    }
 
-        let flat_results = check_graph(
-            &self.dependency_flattened.graph,
-            &self.dependency_flattened.topsort,
-        );
-
-        // remove redundant edges
-        self.dependency_flattened.graph = flat_results.transitive_reduction;
-
-        // flatten: combine `in_set` with `ambiguous_with` information
+    fn get_ambiguous_with_flattened(
+        &self,
+        set_systems: &HashMap<NodeId, Vec<NodeId>>,
+    ) -> GraphMap<NodeId, (), Undirected> {
         let mut ambiguous_with_flattened = UnGraphMap::new();
         for (lhs, rhs, _) in self.ambiguous_with.all_edges() {
             match (lhs, rhs) {
@@ -1044,12 +1019,17 @@ impl ScheduleGraph {
             }
         }
 
-        self.ambiguous_with_flattened = ambiguous_with_flattened;
+        ambiguous_with_flattened
+    }
 
-        // check for conflicts
+    fn get_conflicting_systems(
+        &self,
+        flat_results_disconnected: &Vec<(NodeId, NodeId)>,
+        ambiguous_with_flattened: &GraphMap<NodeId, (), Undirected>,
+    ) -> Vec<(NodeId, NodeId, Vec<ComponentId>)> {
         let mut conflicting_systems = Vec::new();
-        for &(a, b) in &flat_results.disconnected {
-            if self.ambiguous_with_flattened.contains_edge(a, b)
+        for &(a, b) in flat_results_disconnected {
+            if ambiguous_with_flattened.contains_edge(a, b)
                 || self.ambiguous_with_all.contains(&a)
                 || self.ambiguous_with_all.contains(&b)
             {
@@ -1070,18 +1050,15 @@ impl ScheduleGraph {
             }
         }
 
-        if self.settings.ambiguity_detection != LogLevel::Ignore
-            && self.contains_conflicts(&conflicting_systems)
-        {
-            self.report_conflicts(&conflicting_systems, components);
-            if matches!(self.settings.ambiguity_detection, LogLevel::Error) {
-                return Err(ScheduleBuildError::Ambiguity);
-            }
-        }
-        self.conflicting_systems = conflicting_systems;
+        conflicting_systems
+    }
 
-        // build the schedule
-        let dg_system_ids = self.dependency_flattened.topsort.clone();
+    fn build_schedule_inner(
+        &self,
+        dependency_flattened_dag: Dag,
+        hier_results_reachable: FixedBitSet,
+    ) -> SystemSchedule {
+        let dg_system_ids = dependency_flattened_dag.topsort.clone();
         let dg_system_idx_map = dg_system_ids
             .iter()
             .cloned()
@@ -1120,14 +1097,12 @@ impl ScheduleGraph {
         let mut system_dependencies = Vec::with_capacity(sys_count);
         let mut system_dependents = Vec::with_capacity(sys_count);
         for &sys_id in &dg_system_ids {
-            let num_dependencies = self
-                .dependency_flattened
+            let num_dependencies = dependency_flattened_dag
                 .graph
                 .neighbors_directed(sys_id, Direction::Incoming)
                 .count();
 
-            let dependents = self
-                .dependency_flattened
+            let dependents = dependency_flattened_dag
                 .graph
                 .neighbors_directed(sys_id, Direction::Outgoing)
                 .map(|dep_id| dg_system_idx_map[&dep_id])
@@ -1145,7 +1120,7 @@ impl ScheduleGraph {
             let bitset = &mut systems_in_sets_with_conditions[i];
             for &(col, sys_id) in &hg_systems {
                 let idx = dg_system_idx_map[&sys_id];
-                let is_descendant = hier_results.reachable[index(row, col, hg_node_count)];
+                let is_descendant = hier_results_reachable[index(row, col, hg_node_count)];
                 bitset.set(idx, is_descendant);
             }
         }
@@ -1160,12 +1135,12 @@ impl ScheduleGraph {
                 .enumerate()
                 .take_while(|&(_idx, &row)| row < col)
             {
-                let is_ancestor = hier_results.reachable[index(row, col, hg_node_count)];
+                let is_ancestor = hier_results_reachable[index(row, col, hg_node_count)];
                 bitset.set(idx, is_ancestor);
             }
         }
 
-        Ok(SystemSchedule {
+        SystemSchedule {
             systems: Vec::with_capacity(sys_count),
             system_conditions: Vec::with_capacity(sys_count),
             set_conditions: Vec::with_capacity(set_with_conditions_count),
@@ -1175,7 +1150,7 @@ impl ScheduleGraph {
             system_dependents,
             sets_with_conditions_of_systems,
             systems_in_sets_with_conditions,
-        })
+        }
     }
 
     fn update_schedule(
@@ -1292,20 +1267,36 @@ impl ScheduleGraph {
         }
     }
 
-    fn contains_hierarchy_conflicts(&self, transitive_edges: &[(NodeId, NodeId)]) -> bool {
-        if transitive_edges.is_empty() {
-            return false;
+    /// If [`ScheduleBuildSettings::hierarchy_detection`] is [`LogLevel::Ignore`] this check
+    /// is skipped.
+    fn optionally_check_hierarchy_conflicts(
+        &self,
+        transitive_edges: &[(NodeId, NodeId)],
+    ) -> Result<(), ScheduleBuildError> {
+        if self.settings.hierarchy_detection == LogLevel::Ignore || transitive_edges.is_empty() {
+            return Ok(());
         }
 
-        true
+        let message = self.get_hierarchy_conflicts_error_message(transitive_edges);
+        match self.settings.hierarchy_detection {
+            LogLevel::Ignore => unreachable!(),
+            LogLevel::Warn => {
+                error!("{}", message);
+                Ok(())
+            }
+            LogLevel::Error => Err(ScheduleBuildError::HierarchyRedundancy(message)),
+        }
     }
 
-    fn report_hierarchy_conflicts(&self, transitive_edges: &[(NodeId, NodeId)]) {
+    fn get_hierarchy_conflicts_error_message(
+        &self,
+        transitive_edges: &[(NodeId, NodeId)],
+    ) -> String {
         let mut message = String::from("hierarchy contains redundant edge(s)");
         for (parent, child) in transitive_edges {
             writeln!(
                 message,
-                " -- {:?} '{:?}' cannot be child of set '{:?}', longer path exists",
+                " -- {} `{}` cannot be child of set `{}`, longer path exists",
                 self.get_node_kind(child),
                 self.get_node_name(child),
                 self.get_node_name(parent),
@@ -1313,7 +1304,7 @@ impl ScheduleGraph {
             .unwrap();
         }
 
-        error!("{}", message);
+        message
     }
 
     /// Tries to topologically sort `graph`.
@@ -1329,7 +1320,7 @@ impl ScheduleGraph {
         &self,
         graph: &DiGraphMap<NodeId, ()>,
         report: ReportCycles,
-    ) -> Result<Vec<NodeId>, Vec<Vec<NodeId>>> {
+    ) -> Result<Vec<NodeId>, ScheduleBuildError> {
         // Tarjan's SCC algorithm returns elements in *reverse* topological order.
         let mut tarjan_scc = TarjanScc::new();
         let mut top_sorted_nodes = Vec::with_capacity(graph.node_count());
@@ -1355,39 +1346,43 @@ impl ScheduleGraph {
                 cycles.append(&mut simple_cycles_in_component(graph, scc));
             }
 
-            match report {
-                ReportCycles::Hierarchy => self.report_hierarchy_cycles(&cycles),
-                ReportCycles::Dependency => self.report_dependency_cycles(&cycles),
-            }
+            let error = match report {
+                ReportCycles::Hierarchy => ScheduleBuildError::HierarchyCycle(
+                    self.get_hierarchy_cycles_error_message(&cycles),
+                ),
+                ReportCycles::Dependency => ScheduleBuildError::DependencyCycle(
+                    self.get_dependency_cycles_error_message(&cycles),
+                ),
+            };
 
-            Err(sccs_with_cycles)
+            Err(error)
         }
     }
 
     /// Logs details of cycles in the hierarchy graph.
-    fn report_hierarchy_cycles(&self, cycles: &[Vec<NodeId>]) {
+    fn get_hierarchy_cycles_error_message(&self, cycles: &[Vec<NodeId>]) -> String {
         let mut message = format!("schedule has {} in_set cycle(s):\n", cycles.len());
         for (i, cycle) in cycles.iter().enumerate() {
             let mut names = cycle.iter().map(|id| self.get_node_name(id));
             let first_name = names.next().unwrap();
             writeln!(
                 message,
-                "cycle {}: set '{first_name}' contains itself",
+                "cycle {}: set `{first_name}` contains itself",
                 i + 1,
             )
             .unwrap();
-            writeln!(message, "set '{first_name}'").unwrap();
+            writeln!(message, "set `{first_name}`").unwrap();
             for name in names.chain(std::iter::once(first_name)) {
-                writeln!(message, " ... which contains set '{name}'").unwrap();
+                writeln!(message, " ... which contains set `{name}`").unwrap();
             }
             writeln!(message).unwrap();
         }
 
-        error!("{}", message);
+        message
     }
 
     /// Logs details of cycles in the dependency graph.
-    fn report_dependency_cycles(&self, cycles: &[Vec<NodeId>]) {
+    fn get_dependency_cycles_error_message(&self, cycles: &[Vec<NodeId>]) -> String {
         let mut message = format!("schedule has {} before/after cycle(s):\n", cycles.len());
         for (i, cycle) in cycles.iter().enumerate() {
             let mut names = cycle
@@ -1396,36 +1391,119 @@ impl ScheduleGraph {
             let (first_kind, first_name) = names.next().unwrap();
             writeln!(
                 message,
-                "cycle {}: {first_kind} '{first_name}' must run before itself",
+                "cycle {}: {first_kind} `{first_name}` must run before itself",
                 i + 1,
             )
             .unwrap();
-            writeln!(message, "{first_kind} '{first_name}'").unwrap();
+            writeln!(message, "{first_kind} `{first_name}`").unwrap();
             for (kind, name) in names.chain(std::iter::once((first_kind, first_name))) {
-                writeln!(message, " ... which must run before {kind} '{name}'").unwrap();
+                writeln!(message, " ... which must run before {kind} `{name}`").unwrap();
             }
             writeln!(message).unwrap();
         }
 
-        error!("{}", message);
+        message
     }
 
-    fn contains_conflicts(&self, conflicts: &[(NodeId, NodeId, Vec<ComponentId>)]) -> bool {
-        if conflicts.is_empty() {
-            return false;
+    fn check_for_cross_dependencies(
+        &self,
+        dep_results: &CheckGraphResults<NodeId>,
+        hier_results_connected: &HashSet<(NodeId, NodeId)>,
+    ) -> Result<(), ScheduleBuildError> {
+        for &(a, b) in dep_results.connected.iter() {
+            if hier_results_connected.contains(&(a, b)) || hier_results_connected.contains(&(b, a))
+            {
+                let name_a = self.get_node_name(&a);
+                let name_b = self.get_node_name(&b);
+                return Err(ScheduleBuildError::CrossDependency(name_a, name_b));
+            }
         }
 
-        true
+        Ok(())
     }
 
-    fn report_conflicts(
+    fn check_order_but_intersect(
+        &self,
+        dep_results_connected: &HashSet<(NodeId, NodeId)>,
+        set_system_bitsets: &HashMap<NodeId, FixedBitSet>,
+    ) -> Result<(), ScheduleBuildError> {
+        // check that there is no ordering between system sets that intersect
+        for (a, b) in dep_results_connected.iter() {
+            if !(a.is_set() && b.is_set()) {
+                continue;
+            }
+
+            let a_systems = set_system_bitsets.get(a).unwrap();
+            let b_systems = set_system_bitsets.get(b).unwrap();
+
+            if !(a_systems.is_disjoint(b_systems)) {
+                return Err(ScheduleBuildError::SetsHaveOrderButIntersect(
+                    self.get_node_name(a),
+                    self.get_node_name(b),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn check_system_type_set_ambiguity(
+        &self,
+        set_systems: &HashMap<NodeId, Vec<NodeId>>,
+    ) -> Result<(), ScheduleBuildError> {
+        for (&id, systems) in set_systems.iter() {
+            let set = &self.system_sets[id.index()];
+            if set.is_system_type() {
+                let instances = systems.len();
+                let ambiguous_with = self.ambiguous_with.edges(id);
+                let before = self
+                    .dependency
+                    .graph
+                    .edges_directed(id, Direction::Incoming);
+                let after = self
+                    .dependency
+                    .graph
+                    .edges_directed(id, Direction::Outgoing);
+                let relations = before.count() + after.count() + ambiguous_with.count();
+                if instances > 1 && relations > 0 {
+                    return Err(ScheduleBuildError::SystemTypeSetAmbiguity(
+                        self.get_node_name(&id),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// if [`ScheduleBuildSettings::ambiguity_detection`] is [`LogLevel::Ignore`], this check is skipped
+    fn optionally_check_conflicts(
+        &self,
+        conflicts: &[(NodeId, NodeId, Vec<ComponentId>)],
+        components: &Components,
+    ) -> Result<(), ScheduleBuildError> {
+        if self.settings.ambiguity_detection == LogLevel::Ignore || conflicts.is_empty() {
+            return Ok(());
+        }
+
+        let message = self.get_conflicts_error_message(conflicts, components);
+        match self.settings.ambiguity_detection {
+            LogLevel::Ignore => Ok(()),
+            LogLevel::Warn => {
+                warn!("{}", message);
+                Ok(())
+            }
+            LogLevel::Error => Err(ScheduleBuildError::Ambiguity(message)),
+        }
+    }
+
+    fn get_conflicts_error_message(
         &self,
         ambiguities: &[(NodeId, NodeId, Vec<ComponentId>)],
         components: &Components,
-    ) {
+    ) -> String {
         let n_ambiguities = ambiguities.len();
 
-        let mut string = format!(
+        let mut message = format!(
             "{n_ambiguities} pairs of systems with conflicting data access have indeterminate execution order. \
             Consider adding `before`, `after`, or `ambiguous_with` relationships between these:\n",
         );
@@ -1437,22 +1515,22 @@ impl ScheduleGraph {
             debug_assert!(system_a.is_system(), "{name_a} is not a system.");
             debug_assert!(system_b.is_system(), "{name_b} is not a system.");
 
-            writeln!(string, " -- {name_a} and {name_b}").unwrap();
+            writeln!(message, " -- {name_a} and {name_b}").unwrap();
             if !conflicts.is_empty() {
                 let conflict_names: Vec<_> = conflicts
                     .iter()
                     .map(|id| components.get_name(*id).unwrap())
                     .collect();
 
-                writeln!(string, "    conflict on: {conflict_names:?}").unwrap();
+                writeln!(message, "    conflict on: {conflict_names:?}").unwrap();
             } else {
                 // one or both systems must be exclusive
                 let world = std::any::type_name::<World>();
-                writeln!(string, "    conflict on: {world}").unwrap();
+                writeln!(message, "    conflict on: {world}").unwrap();
             }
         }
 
-        warn!("{}", string);
+        message
     }
 
     fn traverse_sets_containing_node(&self, id: NodeId, f: &mut impl FnMut(NodeId) -> bool) {
@@ -1485,33 +1563,33 @@ pub enum ScheduleBuildError {
     #[error("`{0:?}` contains itself.")]
     HierarchyLoop(String),
     /// The hierarchy of system sets contains a cycle.
-    #[error("System set hierarchy contains cycle(s).")]
-    HierarchyCycle,
+    #[error("System set hierarchy contains cycle(s).\n{0}")]
+    HierarchyCycle(String),
     /// The hierarchy of system sets contains redundant edges.
     ///
     /// This error is disabled by default, but can be opted-in using [`ScheduleBuildSettings`].
-    #[error("System set hierarchy contains redundant edges.")]
-    HierarchyRedundancy,
+    #[error("System set hierarchy contains redundant edges.\n{0}")]
+    HierarchyRedundancy(String),
     /// A system (set) has been told to run before itself.
     #[error("`{0:?}` depends on itself.")]
     DependencyLoop(String),
     /// The dependency graph contains a cycle.
-    #[error("System dependencies contain cycle(s).")]
-    DependencyCycle,
+    #[error("System dependencies contain cycle(s).\n{0}")]
+    DependencyCycle(String),
     /// Tried to order a system (set) relative to a system set it belongs to.
-    #[error("`{0:?}` and `{1:?}` have both `in_set` and `before`-`after` relationships (these might be transitive). This combination is unsolvable as a system cannot run before or after a set it belongs to.")]
+    #[error("`{0}` and `{1}` have both `in_set` and `before`-`after` relationships (these might be transitive). This combination is unsolvable as a system cannot run before or after a set it belongs to.")]
     CrossDependency(String, String),
     /// Tried to order system sets that share systems.
-    #[error("`{0:?}` and `{1:?}` have a `before`-`after` relationship (which may be transitive) but share systems.")]
+    #[error("`{0}` and `{1}` have a `before`-`after` relationship (which may be transitive) but share systems.")]
     SetsHaveOrderButIntersect(String, String),
     /// Tried to order a system (set) relative to all instances of some system function.
-    #[error("Tried to order against `fn {0:?}` in a schedule that has more than one `{0:?}` instance. `fn {0:?}` is a `SystemTypeSet` and cannot be used for ordering if ambiguous. Use a different set without this restriction.")]
+    #[error("Tried to order against `{0}` in a schedule that has more than one `{0}` instance. `{0}` is a `SystemTypeSet` and cannot be used for ordering if ambiguous. Use a different set without this restriction.")]
     SystemTypeSetAmbiguity(String),
     /// Systems with conflicting access have indeterminate run order.
     ///
     /// This error is disabled by default, but can be opted-in using [`ScheduleBuildSettings`].
-    #[error("Systems with conflicting access have indeterminate run order.")]
-    Ambiguity,
+    #[error("Systems with conflicting access have indeterminate run order.\n{0}")]
+    Ambiguity(String),
     /// Tried to run a schedule before all of its systems have been initialized.
     #[error("Systems in schedule have not been initialized.")]
     Uninitialized,

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -184,7 +184,7 @@ impl Schedule {
         Self {
             name: label.dyn_clone(),
             graph: ScheduleGraph::new(),
-            executable: SystemSchedule::default(),
+            executable: SystemSchedule::new(),
             executor: make_executor(ExecutorKind::default()),
             executor_initialized: false,
         }
@@ -451,7 +451,7 @@ impl ScheduleGraph {
     #[track_caller]
     pub fn system_at(&self, id: NodeId) -> &dyn System<In = (), Out = ()> {
         self.get_system_at(id)
-            .ok_or_else(|| format!("system with id {id:?} does not exist in this schedule"))
+            .ok_or_else(|| format!("system with id {id:?} does not exist in this Schedule"))
             .unwrap()
     }
 
@@ -469,7 +469,7 @@ impl ScheduleGraph {
     #[track_caller]
     pub fn set_at(&self, id: NodeId) -> &dyn SystemSet {
         self.get_set_at(id)
-            .ok_or_else(|| format!("set with id {id:?} does not exist in this schedule"))
+            .ok_or_else(|| format!("set with id {id:?} does not exist in this Schedule"))
             .unwrap()
     }
 

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -250,7 +250,8 @@ impl Schedule {
         let _span = bevy_utils::tracing::info_span!("schedule", name = ?self.name).entered();
 
         world.check_change_ticks();
-        self.initialize(world).unwrap_or_else(|e| panic!("Error when intializing schedule {:?}: {e}", self.name));
+        self.initialize(world)
+            .unwrap_or_else(|e| panic!("Error when intializing schedule {:?}: {e}", self.name));
         self.executor.run(&mut self.executable, world);
     }
 
@@ -1311,7 +1312,7 @@ impl ScheduleGraph {
     fn optionally_check_hierarchy_conflicts(
         &self,
         transitive_edges: &[(NodeId, NodeId)],
-        schedule_label: &BoxedScheduleLabel
+        schedule_label: &BoxedScheduleLabel,
     ) -> Result<(), ScheduleBuildError> {
         if self.settings.hierarchy_detection == LogLevel::Ignore || transitive_edges.is_empty() {
             return Ok(());
@@ -1321,7 +1322,10 @@ impl ScheduleGraph {
         match self.settings.hierarchy_detection {
             LogLevel::Ignore => unreachable!(),
             LogLevel::Warn => {
-                error!("Schedule {schedule_label:?} has redundant edges:\n {}", message);
+                error!(
+                    "Schedule {schedule_label:?} has redundant edges:\n {}",
+                    message
+                );
                 Ok(())
             }
             LogLevel::Error => Err(ScheduleBuildError::HierarchyRedundancy(message)),

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -400,6 +400,7 @@ impl SystemNode {
 /// Metadata for a [`Schedule`].
 #[derive(Default)]
 pub struct ScheduleGraph {
+    name: BoxedScheduleLabel,
     systems: Vec<SystemNode>,
     system_conditions: Vec<Vec<BoxedCondition>>,
     system_sets: Vec<SystemSetNode>,
@@ -417,8 +418,9 @@ pub struct ScheduleGraph {
 
 impl ScheduleGraph {
     /// Creates an empty [`ScheduleGraph`] with default settings.
-    pub fn new() -> Self {
+    pub fn new(label: impl ScheduleLabel) -> Self {
         Self {
+            name: label.dyn_clone(),
             systems: Vec::new(),
             system_conditions: Vec::new(),
             system_sets: Vec::new(),
@@ -451,7 +453,7 @@ impl ScheduleGraph {
     #[track_caller]
     pub fn system_at(&self, id: NodeId) -> &dyn System<In = (), Out = ()> {
         self.get_system_at(id)
-            .ok_or_else(|| format!("system with id {id:?} does not exist in this Schedule"))
+            .ok_or_else(|| format!("system with id {id:?} does not exist in this schedule `{:?}`", self.name))
             .unwrap()
     }
 
@@ -469,7 +471,7 @@ impl ScheduleGraph {
     #[track_caller]
     pub fn set_at(&self, id: NodeId) -> &dyn SystemSet {
         self.get_set_at(id)
-            .ok_or_else(|| format!("set with id {id:?} does not exist in this Schedule"))
+            .ok_or_else(|| format!("set with id {id:?} does not exist in this schedule `{:?}`", self.name))
             .unwrap()
     }
 

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -103,6 +103,13 @@ impl Schedules {
             schedule.check_change_ticks(change_tick);
         }
     }
+
+    /// Applies the provided [`ScheduleBuildSettings`] to all schedules.
+    pub fn configure_schedules(&mut self, schedule_build_settings: ScheduleBuildSettings) {
+        for (_, schedule) in self.inner.iter_mut() {
+            schedule.set_build_settings(schedule_build_settings.clone());
+        }
+    }
 }
 
 fn make_executor(kind: ExecutorKind) -> Box<dyn SystemExecutor> {
@@ -198,6 +205,11 @@ impl Schedule {
     pub fn set_build_settings(&mut self, settings: ScheduleBuildSettings) -> &mut Self {
         self.graph.settings = settings;
         self
+    }
+
+    /// Returns the schedule's current `ScheduleBuildSettings`.
+    pub fn get_build_settings(&self) -> ScheduleBuildSettings {
+        self.graph.settings.clone()
     }
 
     /// Returns the schedule's current execution strategy.

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -550,8 +550,8 @@ impl ScheduleGraph {
                     let Some(prev) = config_iter.next() else {
                         return AddSystemsInnerResult {
                             nodes: Vec::new(),
-                            densely_chained: true
-                        }
+                            densely_chained: true,
+                        };
                     };
                     let mut previous_result = self.add_systems_inner(prev, true);
                     densely_chained = previous_result.densely_chained;

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -532,14 +532,14 @@ impl ScheduleGraph {
                     if more_than_one_entry {
                         let set = AnonymousSet::new();
                         for config in &mut configs {
-                            config.in_set_inner(set.dyn_clone());
+                            config.in_set_dyn(set.dyn_clone());
                         }
                         let mut set_config = set.into_config();
                         set_config.conditions.extend(collective_conditions);
                         self.configure_set(set_config);
                     } else {
                         for condition in collective_conditions {
-                            configs[0].run_if_inner(condition);
+                            configs[0].run_if_dyn(condition);
                         }
                     }
                 }

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -71,7 +71,7 @@ impl<T: 'static> SystemTypeSet<T> {
 impl<T> Debug for SystemTypeSet<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("SystemTypeSet")
-            .field(&std::any::type_name::<T>())
+            .field(&format_args!("fn {}()", &std::any::type_name::<T>()))
             .finish()
     }
 }

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -83,7 +83,7 @@ impl<T> Hash for SystemTypeSet<T> {
 }
 impl<T> Clone for SystemTypeSet<T> {
     fn clone(&self) -> Self {
-        Self(PhantomData)
+        *self
     }
 }
 

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -198,9 +198,9 @@ mod tests {
 
         let mut world = World::new();
 
-        let mut schedule = Schedule::new();
+        let mut schedule = Schedule::new(A);
         schedule.add_systems(|mut flag: ResMut<Flag>| flag.0 = true);
-        world.add_schedule(schedule, A);
+        world.add_schedule(schedule);
 
         let boxed: Box<dyn ScheduleLabel> = Box::new(A);
 

--- a/crates/bevy_ecs/src/system/adapter_system.rs
+++ b/crates/bevy_ecs/src/system/adapter_system.rs
@@ -1,0 +1,170 @@
+use std::borrow::Cow;
+
+use super::{ReadOnlySystem, System};
+use crate::world::unsafe_world_cell::UnsafeWorldCell;
+
+/// Customizes the behavior of an [`AdapterSystem`]
+///
+/// # Examples
+///
+/// ```
+/// # use bevy_ecs::prelude::*;
+/// use bevy_ecs::system::{Adapt, AdapterSystem};
+///
+/// // A system adapter that inverts the result of a system.
+/// // NOTE: Instead of manually implementing this, you can just use `bevy_ecs::schedule::common_conditions::not`.
+/// pub type NotSystem<S> = AdapterSystem<NotMarker, S>;
+///
+/// // This struct is used to customize the behavior of our adapter.
+/// pub struct NotMarker;
+///
+/// impl<S> Adapt<S> for NotMarker
+/// where
+///     S: System,
+///     S::Out: std::ops::Not,
+/// {
+///     type In = S::In;
+///     type Out = <S::Out as std::ops::Not>::Output;
+///
+///     fn adapt(
+///         &mut self,
+///         input: Self::In,
+///         run_system: impl FnOnce(S::In) -> S::Out,
+///     ) -> Self::Out {
+///         !run_system(input)
+///     }
+/// }
+/// # let mut world = World::new();
+/// # let mut system = NotSystem::new(NotMarker, IntoSystem::into_system(|| false), "".into());
+/// # system.initialize(&mut world);
+/// # assert!(system.run((), &mut world));
+/// ```
+pub trait Adapt<S: System>: Send + Sync + 'static {
+    /// The [input](System::In) type for an [`AdapterSystem`].
+    type In;
+    /// The [output](System::Out) type for an [`AdapterSystem`].
+    type Out;
+
+    /// When used in an [`AdapterSystem`], this function customizes how the system
+    /// is run and how its inputs/outputs are adapted.
+    fn adapt(&mut self, input: Self::In, run_system: impl FnOnce(S::In) -> S::Out) -> Self::Out;
+}
+
+/// A [`System`] that takes the output of `S` and transforms it by applying `Func` to it.
+#[derive(Clone)]
+pub struct AdapterSystem<Func, S> {
+    func: Func,
+    system: S,
+    name: Cow<'static, str>,
+}
+
+impl<Func, S> AdapterSystem<Func, S>
+where
+    Func: Adapt<S>,
+    S: System,
+{
+    /// Creates a new [`System`] that uses `func` to adapt `system`, via the [`Adapt`] trait.
+    pub const fn new(func: Func, system: S, name: Cow<'static, str>) -> Self {
+        Self { func, system, name }
+    }
+}
+
+impl<Func, S> System for AdapterSystem<Func, S>
+where
+    Func: Adapt<S>,
+    S: System,
+{
+    type In = Func::In;
+    type Out = Func::Out;
+
+    fn name(&self) -> Cow<'static, str> {
+        self.name.clone()
+    }
+
+    fn type_id(&self) -> std::any::TypeId {
+        std::any::TypeId::of::<Self>()
+    }
+
+    fn component_access(&self) -> &crate::query::Access<crate::component::ComponentId> {
+        self.system.component_access()
+    }
+
+    #[inline]
+    fn archetype_component_access(
+        &self,
+    ) -> &crate::query::Access<crate::archetype::ArchetypeComponentId> {
+        self.system.archetype_component_access()
+    }
+
+    fn is_send(&self) -> bool {
+        self.system.is_send()
+    }
+
+    fn is_exclusive(&self) -> bool {
+        self.system.is_exclusive()
+    }
+
+    #[inline]
+    unsafe fn run_unsafe(&mut self, input: Self::In, world: UnsafeWorldCell) -> Self::Out {
+        // SAFETY: `system.run_unsafe` has the same invariants as `self.run_unsafe`.
+        self.func
+            .adapt(input, |input| self.system.run_unsafe(input, world))
+    }
+
+    #[inline]
+    fn run(&mut self, input: Self::In, world: &mut crate::prelude::World) -> Self::Out {
+        self.func
+            .adapt(input, |input| self.system.run(input, world))
+    }
+
+    #[inline]
+    fn apply_deferred(&mut self, world: &mut crate::prelude::World) {
+        self.system.apply_deferred(world);
+    }
+
+    fn initialize(&mut self, world: &mut crate::prelude::World) {
+        self.system.initialize(world);
+    }
+
+    #[inline]
+    fn update_archetype_component_access(&mut self, world: UnsafeWorldCell) {
+        self.system.update_archetype_component_access(world);
+    }
+
+    fn check_change_tick(&mut self, change_tick: crate::component::Tick) {
+        self.system.check_change_tick(change_tick);
+    }
+
+    fn get_last_run(&self) -> crate::component::Tick {
+        self.system.get_last_run()
+    }
+
+    fn set_last_run(&mut self, last_run: crate::component::Tick) {
+        self.system.set_last_run(last_run);
+    }
+
+    fn default_system_sets(&self) -> Vec<Box<dyn crate::schedule::SystemSet>> {
+        self.system.default_system_sets()
+    }
+}
+
+// SAFETY: The inner system is read-only.
+unsafe impl<Func, S> ReadOnlySystem for AdapterSystem<Func, S>
+where
+    Func: Adapt<S>,
+    S: ReadOnlySystem,
+{
+}
+
+impl<F, S, Out> Adapt<S> for F
+where
+    S: System,
+    F: Send + Sync + 'static + FnMut(S::Out) -> Out,
+{
+    type In = S::In;
+    type Out = Out;
+
+    fn adapt(&mut self, input: S::In, run_system: impl FnOnce(S::In) -> S::Out) -> Out {
+        self(run_system(input))
+    }
+}

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -50,7 +50,7 @@ use super::{ReadOnlySystem, System};
 /// # let mut world = World::new();
 /// # world.init_resource::<RanFlag>();
 /// #
-/// # let mut app = Schedule::new();
+/// # let mut app = Schedule::default();
 /// app.add_systems(my_system.run_if(Xor::new(
 ///     IntoSystem::into_system(resource_equals(A(1))),
 ///     IntoSystem::into_system(resource_equals(B(1))),

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     self as bevy_ecs,
     bundle::Bundle,
     entity::{Entities, Entity},
-    world::{FromWorld, World},
+    world::{EntityMut, FromWorld, World},
 };
 use bevy_ecs_macros::SystemParam;
 use bevy_utils::tracing::{error, info};
@@ -805,12 +805,13 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::world::EntityMut;
     /// # fn my_system(mut commands: Commands) {
     /// commands
     ///     .spawn_empty()
     ///     // Closures with this signature implement `EntityCommand`.
-    ///     .add(|id: Entity, world: &mut World| {
-    ///         println!("Executed an EntityCommand for {id:?}");
+    ///     .add(|entity: EntityMut| {
+    ///         println!("Executed an EntityCommand for {:?}", entity.id());
     ///     });
     /// # }
     /// # bevy_ecs::system::assert_is_system(my_system);
@@ -848,10 +849,10 @@ where
 
 impl<F> EntityCommand for F
 where
-    F: FnOnce(Entity, &mut World) + Send + 'static,
+    F: FnOnce(EntityMut) + Send + 'static,
 {
     fn apply(self, id: Entity, world: &mut World) {
-        self(id, world);
+        self(world.entity_mut(id));
     }
 }
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -642,8 +642,8 @@ impl<C: EntityCommand> Command for WithEntity<C> {
 
 /// A list of commands that will be run to modify an [entity](crate::entity).
 pub struct EntityCommands<'w, 's, 'a> {
-    entity: Entity,
-    commands: &'a mut Commands<'w, 's>,
+    pub(crate) entity: Entity,
+    pub(crate) commands: &'a mut Commands<'w, 's>,
 }
 
 impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -596,9 +596,9 @@ impl<'w, 's> Commands<'w, 's> {
 /// # let mut world = World::new();
 /// # world.init_resource::<Counter>();
 /// #
-/// # let mut setup_schedule = Schedule::new();
+/// # let mut setup_schedule = Schedule::default();
 /// # setup_schedule.add_systems(setup);
-/// # let mut assert_schedule = Schedule::new();
+/// # let mut assert_schedule = Schedule::default();
 /// # assert_schedule.add_systems(assert_names);
 /// #
 /// # setup_schedule.run(&mut world);

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -170,7 +170,7 @@ pub trait IntoSystem<In, Out, Marker>: Sized {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # let mut schedule = Schedule::new();
+    /// # let mut schedule = Schedule::default();
     /// // Ignores the output of a system that may fail.
     /// schedule.add_systems(my_system.map(std::mem::drop));
     /// # let mut world = World::new();

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -102,6 +102,7 @@
 //! - All tuples between 1 to 16 elements where each element implements [`SystemParam`]
 //! - [`()` (unit primitive type)](https://doc.rust-lang.org/stable/std/primitive.unit.html)
 
+mod adapter_system;
 mod combinator;
 mod commands;
 mod exclusive_function_system;
@@ -114,6 +115,7 @@ mod system_param;
 
 use std::borrow::Cow;
 
+pub use adapter_system::*;
 pub use combinator::*;
 pub use commands::*;
 pub use exclusive_function_system::*;
@@ -162,6 +164,34 @@ pub trait IntoSystem<In, Out, Marker>: Sized {
         let name = format!("Pipe({}, {})", system_a.name(), system_b.name());
         PipeSystem::new(system_a, system_b, Cow::Owned(name))
     }
+
+    /// Pass the output of this system into the passed function `f`, creating a new system that
+    /// outputs the value returned from the function.
+    ///
+    /// ```
+    /// # use bevy_ecs::prelude::*;
+    /// # let mut schedule = Schedule::new();
+    /// // Ignores the output of a system that may fail.
+    /// schedule.add_systems(my_system.map(std::mem::drop));
+    /// # let mut world = World::new();
+    /// # world.insert_resource(T);
+    /// # schedule.run(&mut world);
+    ///
+    /// # #[derive(Resource)] struct T;
+    /// # type Err = ();
+    /// fn my_system(res: Res<T>) -> Result<(), Err> {
+    ///     // ...
+    ///     # Err(())
+    /// }
+    /// ```
+    fn map<T, F>(self, f: F) -> AdapterSystem<F, Self::System>
+    where
+        F: Send + Sync + 'static + FnMut(Out) -> T,
+    {
+        let system = Self::into_system(self);
+        let name = system.name();
+        AdapterSystem::new(f, system, name)
+    }
 }
 
 // All systems implicitly implement IntoSystem.
@@ -201,6 +231,7 @@ impl<T: System> IntoSystem<T::In, T::Out, ()> for T {
 pub struct In<In>(pub In);
 
 /// A collection of common adapters for [piping](crate::system::PipeSystem) the result of a system.
+#[deprecated = "this form of system adapter has been deprecated in favor of `system.map(...)`"]
 pub mod adapter {
     use crate::system::In;
     use bevy_utils::tracing;
@@ -223,6 +254,7 @@ pub mod adapter {
     ///     println!("{x:?}");
     /// }
     /// ```
+    #[deprecated = "use `.map(...)` instead"]
     pub fn new<T, U>(mut f: impl FnMut(T) -> U) -> impl FnMut(In<T>) -> U {
         move |In(x)| f(x)
     }
@@ -260,6 +292,7 @@ pub mod adapter {
     /// # fn open_file(name: &str) -> Result<&'static str, std::io::Error>
     /// # { Ok("hello world") }
     /// ```
+    #[deprecated = "use `.map(Result::unwrap)` instead"]
     pub fn unwrap<T, E: Debug>(In(res): In<Result<T, E>>) -> T {
         res.unwrap()
     }
@@ -287,6 +320,7 @@ pub mod adapter {
     ///     "42".to_string()
     /// }
     /// ```
+    #[deprecated = "use `.map(bevy_utils::info)` instead"]
     pub fn info<T: Debug>(In(data): In<T>) {
         tracing::info!("{:?}", data);
     }
@@ -314,6 +348,7 @@ pub mod adapter {
     ///     Ok("42".parse()?)
     /// }
     /// ```
+    #[deprecated = "use `.map(bevy_utils::dbg)` instead"]
     pub fn dbg<T: Debug>(In(data): In<T>) {
         tracing::debug!("{:?}", data);
     }
@@ -341,6 +376,7 @@ pub mod adapter {
     ///     Err("Got to rusty?".to_string())
     /// }
     /// ```
+    #[deprecated = "use `.map(bevy_utils::warn)` instead"]
     pub fn warn<E: Debug>(In(res): In<Result<(), E>>) {
         if let Err(warn) = res {
             tracing::warn!("{:?}", warn);
@@ -369,6 +405,7 @@ pub mod adapter {
     ///    Err("Some error".to_owned())
     /// }
     /// ```
+    #[deprecated = "use `.map(bevy_utils::error)` instead"]
     pub fn error<E: Debug>(In(res): In<Result<(), E>>) {
         if let Err(error) = res {
             tracing::error!("{:?}", error);
@@ -409,6 +446,7 @@ pub mod adapter {
     ///     Some(())
     /// }
     /// ```
+    #[deprecated = "use `.map(std::mem::drop)` instead"]
     pub fn ignore<T>(In(_): In<T>) {}
 }
 
@@ -510,7 +548,7 @@ mod tests {
             Schedule,
         },
         system::{
-            adapter::new, Commands, In, IntoSystem, Local, NonSend, NonSendMut, ParamSet, Query,
+            Commands, In, IntoSystem, Local, NonSend, NonSendMut, ParamSet, Query,
             QueryComponentError, Res, ResMut, Resource, System, SystemState,
         },
         world::{FromWorld, World},
@@ -1785,10 +1823,10 @@ mod tests {
             !val
         }
 
-        assert_is_system(returning::<Result<u32, std::io::Error>>.pipe(unwrap));
-        assert_is_system(returning::<Option<()>>.pipe(ignore));
-        assert_is_system(returning::<&str>.pipe(new(u64::from_str)).pipe(unwrap));
-        assert_is_system(exclusive_in_out::<(), Result<(), std::io::Error>>.pipe(error));
+        assert_is_system(returning::<Result<u32, std::io::Error>>.map(Result::unwrap));
+        assert_is_system(returning::<Option<()>>.map(std::mem::drop));
+        assert_is_system(returning::<&str>.map(u64::from_str).map(Result::unwrap));
+        assert_is_system(exclusive_in_out::<(), Result<(), std::io::Error>>.map(bevy_utils::error));
         assert_is_system(returning::<bool>.pipe(exclusive_in_out::<bool, ()>));
 
         returning::<()>.run_if(returning::<bool>.pipe(not));

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -1916,7 +1916,7 @@ mod tests {
 
         world.insert_resource(A);
         world.insert_resource(C(0));
-        let mut sched = Schedule::new();
+        let mut sched = Schedule::default();
         sched.add_systems(
             (
                 (|mut res: ResMut<C>| {

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -55,7 +55,7 @@
 //!
 //! ```
 //! # use bevy_ecs::prelude::*;
-//! # let mut schedule = Schedule::new();
+//! # let mut schedule = Schedule::default();
 //! # let mut world = World::new();
 //! // Configure these systems to run in order using `chain()`.
 //! schedule.add_systems((print_first, print_last).chain());

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -151,19 +151,11 @@ pub(crate) fn check_system_change_tick(last_run: &mut Tick, this_run: Tick, syst
 
 impl<In: 'static, Out: 'static> Debug for dyn System<In = In, Out = Out> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "System {}: {{{}}}", self.name(), {
-            if self.is_send() {
-                if self.is_exclusive() {
-                    "is_send is_exclusive"
-                } else {
-                    "is_send"
-                }
-            } else if self.is_exclusive() {
-                "is_exclusive"
-            } else {
-                ""
-            }
-        },)
+        f.debug_struct("System")
+            .field("name", &self.name())
+            .field("is_exclusive", &self.is_exclusive())
+            .field("is_send", &self.is_send())
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -149,7 +149,7 @@ pub(crate) fn check_system_change_tick(last_run: &mut Tick, this_run: Tick, syst
     }
 }
 
-impl Debug for dyn System<In = (), Out = ()> {
+impl<In: 'static, Out: 'static> Debug for dyn System<In = In, Out = Out> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "System {}: {{{}}}", self.name(), {
             if self.is_send() {

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -679,19 +679,11 @@ unsafe impl SystemParam for &'_ World {
 /// // .add_systems(reset_to_system(my_config))
 /// # assert_is_system(reset_to_system(Config(10)));
 /// ```
+#[derive(Debug)]
 pub struct Local<'s, T: FromWorld + Send + 'static>(pub(crate) &'s mut T);
 
 // SAFETY: Local only accesses internal state
 unsafe impl<'s, T: FromWorld + Send + 'static> ReadOnlySystemParam for Local<'s, T> {}
-
-impl<'s, T: FromWorld + Send + Sync + 'static> Debug for Local<'s, T>
-where
-    T: Debug,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("Local").field(&self.0).finish()
-    }
-}
 
 impl<'s, T: FromWorld + Send + Sync + 'static> Deref for Local<'s, T> {
     type Target = T;
@@ -1300,14 +1292,13 @@ unsafe impl SystemParam for SystemChangeTick {
 ///
 /// This is not a reliable identifier, it is more so useful for debugging
 /// purposes of finding where a system parameter is being used incorrectly.
-pub struct SystemName<'s> {
-    name: &'s str,
-}
+#[derive(Debug)]
+pub struct SystemName<'s>(&'s str);
 
 impl<'s> SystemName<'s> {
     /// Gets the name of the system.
     pub fn name(&self) -> &str {
-        self.name
+        self.0
     }
 }
 
@@ -1326,14 +1317,7 @@ impl<'s> AsRef<str> for SystemName<'s> {
 
 impl<'s> From<SystemName<'s>> for &'s str {
     fn from(name: SystemName<'s>) -> &'s str {
-        name.name
-    }
-}
-
-impl<'s> std::fmt::Debug for SystemName<'s> {
-    #[inline(always)]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.debug_tuple("SystemName").field(&self.name()).finish()
+        name.0
     }
 }
 
@@ -1360,7 +1344,7 @@ unsafe impl SystemParam for SystemName<'_> {
         _world: UnsafeWorldCell<'w>,
         _change_tick: Tick,
     ) -> Self::Item<'w, 's> {
-        SystemName { name }
+        SystemName(name)
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1735,7 +1735,7 @@ mod tests {
         }
 
         let mut world = World::new();
-        let mut schedule = crate::schedule::Schedule::new();
+        let mut schedule = crate::schedule::Schedule::default();
         schedule.add_systems(non_sync_system);
         schedule.run(&mut world);
     }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -353,7 +353,7 @@ impl_param_set!();
 ///
 /// ```
 /// # let mut world = World::default();
-/// # let mut schedule = Schedule::new();
+/// # let mut schedule = Schedule::default();
 /// # use bevy_ecs::prelude::*;
 /// #[derive(Resource)]
 /// struct MyResource { value: u32 }
@@ -854,7 +854,7 @@ pub trait SystemBuffer: FromWorld + Send + 'static {
 ///     // ...
 /// });
 ///
-/// let mut schedule = Schedule::new();
+/// let mut schedule = Schedule::default();
 /// // These two systems have no conflicts and will run in parallel.
 /// schedule.add_systems((alert_criminal, alert_monster));
 ///

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -685,7 +685,7 @@ pub struct Local<'s, T: FromWorld + Send + 'static>(pub(crate) &'s mut T);
 // SAFETY: Local only accesses internal state
 unsafe impl<'s, T: FromWorld + Send + 'static> ReadOnlySystemParam for Local<'s, T> {}
 
-impl<'s, T: FromWorld + Send + Sync + 'static> Deref for Local<'s, T> {
+impl<'s, T: FromWorld + Send + 'static> Deref for Local<'s, T> {
     type Target = T;
 
     #[inline]
@@ -694,7 +694,7 @@ impl<'s, T: FromWorld + Send + Sync + 'static> Deref for Local<'s, T> {
     }
 }
 
-impl<'s, T: FromWorld + Send + Sync + 'static> DerefMut for Local<'s, T> {
+impl<'s, T: FromWorld + Send + 'static> DerefMut for Local<'s, T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0
@@ -1560,7 +1560,7 @@ mod tests {
         query::{ReadOnlyWorldQuery, WorldQuery},
         system::{assert_is_system, Query},
     };
-    use std::marker::PhantomData;
+    use std::{cell::RefCell, marker::PhantomData};
 
     // Compile test for https://github.com/bevyengine/bevy/pull/2838.
     #[test]
@@ -1725,5 +1725,18 @@ mod tests {
 
         fn my_system(_: InvariantParam) {}
         assert_is_system(my_system);
+    }
+
+    // Compile test for https://github.com/bevyengine/bevy/pull/9589.
+    #[test]
+    fn non_sync_local() {
+        fn non_sync_system(cell: Local<RefCell<u8>>) {
+            assert_eq!(*cell.borrow(), 0);
+        }
+
+        let mut world = World::new();
+        let mut schedule = crate::schedule::Schedule::new();
+        schedule.add_systems(non_sync_system);
+        schedule.run(&mut world);
     }
 }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1807,7 +1807,7 @@ impl World {
     /// # let mut schedule = Schedule::default();
     /// # schedule.add_systems(tick_counter);
     /// # world.init_resource::<Schedules>();
-    /// # world.add_schedule(schedule, MySchedule);
+    /// # world.add_schedule(schedule);
     /// # fn tick_counter(mut counter: ResMut<Counter>) { counter.0 += 1; }
     /// // Run the schedule five times.
     /// world.schedule_scope(MySchedule, |world, schedule| {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1770,7 +1770,7 @@ impl World {
         f: impl FnOnce(&mut World, &mut Schedule) -> R,
     ) -> Result<R, TryRunScheduleError> {
         let label = label.as_ref();
-        let Some((extracted_label, mut schedule)) = self
+        let Some((_, mut schedule)) = self
             .get_resource_mut::<Schedules>()
             .and_then(|mut s| s.remove_entry(label))
         else {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1770,8 +1770,9 @@ impl World {
         f: impl FnOnce(&mut World, &mut Schedule) -> R,
     ) -> Result<R, TryRunScheduleError> {
         let label = label.as_ref();
-        let Some((extracted_label, mut schedule))
-            = self.get_resource_mut::<Schedules>().and_then(|mut s| s.remove_entry(label))
+        let Some((extracted_label, mut schedule)) = self
+            .get_resource_mut::<Schedules>()
+            .and_then(|mut s| s.remove_entry(label))
         else {
             return Err(TryRunScheduleError(label.dyn_clone()));
         };

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1770,9 +1770,9 @@ impl World {
         f: impl FnOnce(&mut World, &mut Schedule) -> R,
     ) -> Result<R, TryRunScheduleError> {
         let label = label.as_ref();
-        let Some((_, mut schedule)) = self
+        let Some(mut schedule) = self
             .get_resource_mut::<Schedules>()
-            .and_then(|mut s| s.remove_entry(label))
+            .and_then(|mut s| s.remove(label))
         else {
             return Err(TryRunScheduleError(label.dyn_clone()));
         };

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1748,9 +1748,9 @@ impl World {
     /// accessing the [`Schedules`] resource.
     ///
     /// The `Schedules` resource will be initialized if it does not already exist.
-    pub fn add_schedule(&mut self, schedule: Schedule, label: impl ScheduleLabel) {
+    pub fn add_schedule(&mut self, schedule: Schedule) {
         let mut schedules = self.get_resource_or_insert_with(Schedules::default);
-        schedules.insert(label, schedule);
+        schedules.insert(schedule);
     }
 
     /// Temporarily removes the schedule associated with `label` from the world,
@@ -1784,7 +1784,7 @@ impl World {
 
         let old = self
             .resource_mut::<Schedules>()
-            .insert(extracted_label, schedule);
+            .insert(schedule);
         if old.is_some() {
             warn!("Schedule `{label:?}` was inserted during a call to `World::schedule_scope`: its value has been overwritten");
         }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1804,7 +1804,7 @@ impl World {
     /// #
     /// # let mut world = World::new();
     /// # world.insert_resource(Counter(0));
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedule = Schedule::new(MySchedule);
     /// # schedule.add_systems(tick_counter);
     /// # world.init_resource::<Schedules>();
     /// # world.add_schedule(schedule);

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1777,14 +1777,9 @@ impl World {
             return Err(TryRunScheduleError(label.dyn_clone()));
         };
 
-        // TODO: move this span to Schedule::run
-        #[cfg(feature = "trace")]
-        let _span = bevy_utils::tracing::info_span!("schedule", name = ?extracted_label).entered();
         let value = f(self, &mut schedule);
 
-        let old = self
-            .resource_mut::<Schedules>()
-            .insert(schedule);
+        let old = self.resource_mut::<Schedules>().insert(schedule);
         if old.is_some() {
             warn!("Schedule `{label:?}` was inserted during a call to `World::schedule_scope`: its value has been overwritten");
         }
@@ -1809,7 +1804,7 @@ impl World {
     /// #
     /// # let mut world = World::new();
     /// # world.insert_resource(Counter(0));
-    /// # let mut schedule = Schedule::new();
+    /// # let mut schedule = Schedule::default();
     /// # schedule.add_systems(tick_counter);
     /// # world.init_resource::<Schedules>();
     /// # world.add_schedule(schedule, MySchedule);

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_exact_sized_iterator_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_exact_sized_iterator_safety.stderr
@@ -7,14 +7,14 @@ error[E0277]: the trait bound `bevy_ecs::query::Changed<Foo>: ArchetypeFilter` i
    |     required by a bound introduced by this call
    |
    = help: the following other types implement trait `ArchetypeFilter`:
-             ()
-             (F0, F1)
-             (F0, F1, F2)
-             (F0, F1, F2, F3)
-             (F0, F1, F2, F3, F4)
-             (F0, F1, F2, F3, F4, F5)
-             (F0, F1, F2, F3, F4, F5, F6)
-             (F0, F1, F2, F3, F4, F5, F6, F7)
+             With<T>
+             Without<T>
+             Or<()>
+             Or<(F0,)>
+             Or<(F0, F1)>
+             Or<(F0, F1, F2)>
+             Or<(F0, F1, F2, F3)>
+             Or<(F0, F1, F2, F3, F4)>
            and $N others
    = note: required for `QueryIter<'_, '_, &Foo, bevy_ecs::query::Changed<Foo>>` to implement `ExactSizeIterator`
 note: required by a bound in `is_exact_size_iterator`
@@ -32,14 +32,14 @@ error[E0277]: the trait bound `bevy_ecs::query::Added<Foo>: ArchetypeFilter` is 
    |     required by a bound introduced by this call
    |
    = help: the following other types implement trait `ArchetypeFilter`:
-             ()
-             (F0, F1)
-             (F0, F1, F2)
-             (F0, F1, F2, F3)
-             (F0, F1, F2, F3, F4)
-             (F0, F1, F2, F3, F4, F5)
-             (F0, F1, F2, F3, F4, F5, F6)
-             (F0, F1, F2, F3, F4, F5, F6, F7)
+             With<T>
+             Without<T>
+             Or<()>
+             Or<(F0,)>
+             Or<(F0, F1)>
+             Or<(F0, F1, F2)>
+             Or<(F0, F1, F2, F3)>
+             Or<(F0, F1, F2, F3, F4)>
            and $N others
    = note: required for `QueryIter<'_, '_, &Foo, bevy_ecs::query::Added<Foo>>` to implement `ExactSizeIterator`
 note: required by a bound in `is_exact_size_iterator`

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_combinations_mut_iterator_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_combinations_mut_iterator_safety.stderr
@@ -7,14 +7,14 @@ error[E0277]: the trait bound `&mut A: ReadOnlyWorldQuery` is not satisfied
    |     required by a bound introduced by this call
    |
    = help: the following other types implement trait `ReadOnlyWorldQuery`:
-             &T
-             ()
-             (F0, F1)
-             (F0, F1, F2)
-             (F0, F1, F2, F3)
-             (F0, F1, F2, F3, F4)
-             (F0, F1, F2, F3, F4, F5)
-             (F0, F1, F2, F3, F4, F5, F6)
+             bevy_ecs::change_detection::Ref<'__w, T>
+             Has<T>
+             AnyOf<()>
+             AnyOf<(F0,)>
+             AnyOf<(F0, F1)>
+             AnyOf<(F0, F1, F2)>
+             AnyOf<(F0, F1, F2, F3)>
+             AnyOf<(F0, F1, F2, F3, F4)>
            and $N others
    = note: `ReadOnlyWorldQuery` is implemented for `&A`, but not for `&mut A`
    = note: required for `QueryCombinationIter<'_, '_, &mut A, (), _>` to implement `Iterator`

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_many_mut_iterator_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_many_mut_iterator_safety.stderr
@@ -7,14 +7,14 @@ error[E0277]: the trait bound `&mut A: ReadOnlyWorldQuery` is not satisfied
    |     required by a bound introduced by this call
    |
    = help: the following other types implement trait `ReadOnlyWorldQuery`:
-             &T
-             ()
-             (F0, F1)
-             (F0, F1, F2)
-             (F0, F1, F2, F3)
-             (F0, F1, F2, F3, F4)
-             (F0, F1, F2, F3, F4, F5)
-             (F0, F1, F2, F3, F4, F5, F6)
+             bevy_ecs::change_detection::Ref<'__w, T>
+             Has<T>
+             AnyOf<()>
+             AnyOf<(F0,)>
+             AnyOf<(F0, F1)>
+             AnyOf<(F0, F1, F2)>
+             AnyOf<(F0, F1, F2, F3)>
+             AnyOf<(F0, F1, F2, F3, F4)>
            and $N others
    = note: `ReadOnlyWorldQuery` is implemented for `&A`, but not for `&mut A`
    = note: required for `QueryManyIter<'_, '_, &mut A, (), std::array::IntoIter<bevy_ecs::entity::Entity, 1>>` to implement `Iterator`

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
@@ -13,14 +13,14 @@ error[E0277]: the trait bound `&'static mut Foo: ReadOnlyWorldQuery` is not sati
    |                       ^^^^^^^ the trait `ReadOnlyWorldQuery` is not implemented for `&'static mut Foo`
    |
    = help: the following other types implement trait `ReadOnlyWorldQuery`:
-             &T
-             ()
-             (F0, F1)
-             (F0, F1, F2)
-             (F0, F1, F2, F3)
-             (F0, F1, F2, F3, F4)
-             (F0, F1, F2, F3, F4, F5)
-             (F0, F1, F2, F3, F4, F5, F6)
+             bevy_ecs::change_detection::Ref<'__w, T>
+             Has<T>
+             AnyOf<()>
+             AnyOf<(F0,)>
+             AnyOf<(F0, F1)>
+             AnyOf<(F0, F1, F2)>
+             AnyOf<(F0, F1, F2, F3)>
+             AnyOf<(F0, F1, F2, F3, F4)>
            and $N others
    = note: `ReadOnlyWorldQuery` is implemented for `&'static Foo`, but not for `&'static mut Foo`
    = note: required for `bevy_ecs::system::Query<'_, '_, &'static mut Foo>` to implement `ReadOnlySystemParam`

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/world_query_derive.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/world_query_derive.stderr
@@ -5,14 +5,14 @@ error[E0277]: the trait bound `&'static mut Foo: ReadOnlyWorldQuery` is not sati
   |        ^^^^^^^^^^^^^^^^ the trait `ReadOnlyWorldQuery` is not implemented for `&'static mut Foo`
   |
   = help: the following other types implement trait `ReadOnlyWorldQuery`:
-            &T
-            ()
-            (F0, F1)
-            (F0, F1, F2)
-            (F0, F1, F2, F3)
-            (F0, F1, F2, F3, F4)
-            (F0, F1, F2, F3, F4, F5)
-            (F0, F1, F2, F3, F4, F5, F6)
+            MutableUnmarked
+            MutableMarkedReadOnly
+            NestedMutableUnmarked
+            bevy_ecs::change_detection::Ref<'__w, T>
+            Has<T>
+            AnyOf<()>
+            AnyOf<(F0,)>
+            AnyOf<(F0, F1)>
           and $N others
 note: required by a bound in `_::assert_readonly`
  --> tests/ui/world_query_derive.rs:7:10
@@ -28,14 +28,14 @@ error[E0277]: the trait bound `MutableMarked: ReadOnlyWorldQuery` is not satisfi
    |        ^^^^^^^^^^^^^ the trait `ReadOnlyWorldQuery` is not implemented for `MutableMarked`
    |
    = help: the following other types implement trait `ReadOnlyWorldQuery`:
-             &T
-             ()
-             (F0, F1)
-             (F0, F1, F2)
-             (F0, F1, F2, F3)
-             (F0, F1, F2, F3, F4)
-             (F0, F1, F2, F3, F4, F5)
-             (F0, F1, F2, F3, F4, F5, F6)
+             MutableUnmarked
+             MutableMarkedReadOnly
+             NestedMutableUnmarked
+             bevy_ecs::change_detection::Ref<'__w, T>
+             Has<T>
+             AnyOf<()>
+             AnyOf<(F0,)>
+             AnyOf<(F0, F1)>
            and $N others
 note: required by a bound in `_::assert_readonly`
   --> tests/ui/world_query_derive.rs:18:10

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -152,7 +152,7 @@ impl<'s> Gizmos<'s> {
     /// ```
     #[inline]
     pub fn linestrip(&mut self, positions: impl IntoIterator<Item = Vec3>, color: Color) {
-        self.extend_strip_positions(positions.into_iter());
+        self.extend_strip_positions(positions);
         let len = self.buffer.strip_positions.len();
         self.buffer
             .strip_colors

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -96,7 +96,9 @@ impl Plugin for GizmoPlugin {
                     .after(TransformSystem::TransformPropagate),
             );
 
-        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return; };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
 
         render_app
             .add_systems(ExtractSchedule, extract_gizmo_data)
@@ -109,7 +111,9 @@ impl Plugin for GizmoPlugin {
     }
 
     fn finish(&self, app: &mut bevy_app::App) {
-        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return; };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
 
         let render_device = render_app.world.resource::<RenderDevice>();
         let layout = render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -102,7 +102,10 @@ impl Plugin for GizmoPlugin {
 
         render_app
             .add_systems(ExtractSchedule, extract_gizmo_data)
-            .add_systems(Render, queue_line_gizmo_bind_group.in_set(RenderSet::Queue));
+            .add_systems(
+                Render,
+                prepare_line_gizmo_bind_group.in_set(RenderSet::PrepareBindGroups),
+            );
 
         #[cfg(feature = "bevy_sprite")]
         app.add_plugins(pipeline_2d::LineGizmo2dPlugin);
@@ -413,7 +416,7 @@ struct LineGizmoUniformBindgroup {
     bindgroup: BindGroup,
 }
 
-fn queue_line_gizmo_bind_group(
+fn prepare_line_gizmo_bind_group(
     mut commands: Commands,
     line_gizmo_uniform_layout: Res<LineGizmoUniformBindgroupLayout>,
     render_device: Res<RenderDevice>,

--- a/crates/bevy_gizmos/src/pipeline_2d.rs
+++ b/crates/bevy_gizmos/src/pipeline_2d.rs
@@ -27,7 +27,9 @@ pub struct LineGizmo2dPlugin;
 
 impl Plugin for LineGizmo2dPlugin {
     fn build(&self, app: &mut App) {
-        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
 
         render_app
             .add_render_command::<Transparent2d, DrawLineGizmo2d>()
@@ -36,7 +38,9 @@ impl Plugin for LineGizmo2dPlugin {
     }
 
     fn finish(&self, app: &mut App) {
-        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
 
         render_app.init_resource::<LineGizmoPipeline>();
     }
@@ -151,7 +155,9 @@ fn queue_line_gizmos_2d(
             | Mesh2dPipelineKey::from_hdr(view.hdr);
 
         for (entity, handle) in &line_gizmos {
-            let Some(line_gizmo) = line_gizmo_assets.get(handle) else { continue };
+            let Some(line_gizmo) = line_gizmo_assets.get(handle) else {
+                continue;
+            };
 
             let pipeline = pipelines.specialize(
                 &pipeline_cache,

--- a/crates/bevy_gizmos/src/pipeline_2d.rs
+++ b/crates/bevy_gizmos/src/pipeline_2d.rs
@@ -13,7 +13,7 @@ use bevy_ecs::{
     world::{FromWorld, World},
 };
 use bevy_render::{
-    render_asset::RenderAssets,
+    render_asset::{prepare_assets, RenderAssets},
     render_phase::{AddRenderCommand, DrawFunctions, RenderPhase, SetItemPipeline},
     render_resource::*,
     texture::BevyDefault,
@@ -34,7 +34,12 @@ impl Plugin for LineGizmo2dPlugin {
         render_app
             .add_render_command::<Transparent2d, DrawLineGizmo2d>()
             .init_resource::<SpecializedRenderPipelines<LineGizmoPipeline>>()
-            .add_systems(Render, queue_line_gizmos_2d.in_set(RenderSet::Queue));
+            .add_systems(
+                Render,
+                queue_line_gizmos_2d
+                    .in_set(RenderSet::Queue)
+                    .after(prepare_assets::<LineGizmo>),
+            );
     }
 
     fn finish(&self, app: &mut App) {
@@ -173,7 +178,7 @@ fn queue_line_gizmos_2d(
                 draw_function,
                 pipeline,
                 sort_key: FloatOrd(f32::INFINITY),
-                batch_range: None,
+                batch_size: 1,
             });
         }
     }

--- a/crates/bevy_gizmos/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos/src/pipeline_3d.rs
@@ -14,7 +14,7 @@ use bevy_ecs::{
 };
 use bevy_pbr::{MeshPipeline, MeshPipelineKey, SetMeshViewBindGroup};
 use bevy_render::{
-    render_asset::RenderAssets,
+    render_asset::{prepare_assets, RenderAssets},
     render_phase::{AddRenderCommand, DrawFunctions, RenderPhase, SetItemPipeline},
     render_resource::*,
     texture::BevyDefault,
@@ -32,7 +32,12 @@ impl Plugin for LineGizmo3dPlugin {
         render_app
             .add_render_command::<Transparent3d, DrawLineGizmo3d>()
             .init_resource::<SpecializedRenderPipelines<LineGizmoPipeline>>()
-            .add_systems(Render, queue_line_gizmos_3d.in_set(RenderSet::Queue));
+            .add_systems(
+                Render,
+                queue_line_gizmos_3d
+                    .in_set(RenderSet::Queue)
+                    .after(prepare_assets::<LineGizmo>),
+            );
     }
 
     fn finish(&self, app: &mut App) {
@@ -187,6 +192,7 @@ fn queue_line_gizmos_3d(
                 draw_function,
                 pipeline,
                 distance: 0.,
+                batch_size: 1,
             });
         }
     }

--- a/crates/bevy_gizmos/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos/src/pipeline_3d.rs
@@ -25,7 +25,9 @@ use bevy_render::{
 pub struct LineGizmo3dPlugin;
 impl Plugin for LineGizmo3dPlugin {
     fn build(&self, app: &mut App) {
-        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
 
         render_app
             .add_render_command::<Transparent3d, DrawLineGizmo3d>()
@@ -34,7 +36,9 @@ impl Plugin for LineGizmo3dPlugin {
     }
 
     fn finish(&self, app: &mut App) {
-        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
 
         render_app.init_resource::<LineGizmoPipeline>();
     }
@@ -164,7 +168,9 @@ fn queue_line_gizmos_3d(
             | MeshPipelineKey::from_hdr(view.hdr);
 
         for (entity, handle) in &line_gizmos {
-            let Some(line_gizmo) = line_gizmo_assets.get(handle) else { continue };
+            let Some(line_gizmo) = line_gizmo_assets.get(handle) else {
+                continue;
+            };
 
             let pipeline = pipelines.specialize(
                 &pipeline_cache,

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -11,7 +11,7 @@ use bevy_log::warn;
 use bevy_math::{Mat4, Vec3};
 use bevy_pbr::{
     AlphaMode, DirectionalLight, DirectionalLightBundle, PbrBundle, PointLight, PointLightBundle,
-    SpotLight, SpotLightBundle, StandardMaterial,
+    SpotLight, SpotLightBundle, StandardMaterial, MAX_JOINTS,
 };
 use bevy_render::{
     camera::{Camera, OrthographicProjection, PerspectiveProjection, Projection, ScalingMode},
@@ -489,6 +489,7 @@ async fn load_gltf<'a, 'b>(
             }
         }
 
+        let mut warned_about_max_joints = HashSet::new();
         for (&entity, &skin_index) in &entity_to_skin_index_map {
             let mut entity = world.entity_mut(entity);
             let skin = gltf.skins().nth(skin_index).unwrap();
@@ -497,6 +498,16 @@ async fn load_gltf<'a, 'b>(
                 .map(|node| node_index_to_entity_map[&node.index()])
                 .collect();
 
+            if joint_entities.len() > MAX_JOINTS && warned_about_max_joints.insert(skin_index) {
+                warn!(
+                    "The glTF skin {:?} has {} joints, but the maximum supported is {}",
+                    skin.name()
+                        .map(|name| name.to_string())
+                        .unwrap_or_else(|| skin.index().to_string()),
+                    joint_entities.len(),
+                    MAX_JOINTS
+                );
+            }
             entity.insert(SkinnedMesh {
                 inverse_bindposes: skinned_mesh_inverse_bindposes[skin_index].clone(),
                 joints: joint_entities,

--- a/crates/bevy_macros_compile_fail_tests/tests/deref_derive/multiple_fields.pass.rs
+++ b/crates/bevy_macros_compile_fail_tests/tests/deref_derive/multiple_fields.pass.rs
@@ -5,9 +5,13 @@ struct TupleStruct(usize, #[deref] String);
 
 #[derive(Deref)]
 struct Struct {
+    // Works with other attributes
+    #[cfg(test)]
     foo: usize,
     #[deref]
     bar: String,
+    /// Also works with doc comments.
+    baz: i32,
 }
 
 fn main() {
@@ -15,8 +19,10 @@ fn main() {
     let _: &String = &*value;
 
     let value = Struct {
+        #[cfg(test)]
         foo: 123,
         bar: "Hello world!".to_string(),
+        baz: 321,
     };
     let _: &String = &*value;
 }

--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -133,10 +133,7 @@ impl<P: Point> Hermite<P> {
         tangents: impl IntoIterator<Item = P>,
     ) -> Self {
         Self {
-            control_points: control_points
-                .into_iter()
-                .zip(tangents.into_iter())
-                .collect(),
+            control_points: control_points.into_iter().zip(tangents).collect(),
         }
     }
 }

--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -28,7 +28,7 @@ impl Point for Vec3A {}
 impl Point for Vec2 {}
 impl Point for f32 {}
 
-/// A spline composed of a series of cubic Bezier curves.
+/// A spline composed of a single cubic Bezier curve.
 ///
 /// Useful for user-drawn curves with local control, or animation easing. See
 /// [`CubicSegment::new_bezier`] for use in easing.
@@ -53,22 +53,22 @@ impl Point for f32 {}
 ///     vec2(5.0, 3.0),
 ///     vec2(9.0, 8.0),
 /// ]];
-/// let bezier = Bezier::new(points).to_curve();
+/// let bezier = CubicBezier::new(points).to_curve();
 /// let positions: Vec<_> = bezier.iter_positions(100).collect();
 /// ```
-pub struct Bezier<P: Point> {
+pub struct CubicBezier<P: Point> {
     control_points: Vec<[P; 4]>,
 }
 
-impl<P: Point> Bezier<P> {
-    /// Create a new Bezier curve from sets of control points.
+impl<P: Point> CubicBezier<P> {
+    /// Create a new cubic Bezier curve from sets of control points.
     pub fn new(control_points: impl Into<Vec<[P; 4]>>) -> Self {
         Self {
             control_points: control_points.into(),
         }
     }
 }
-impl<P: Point> CubicGenerator<P> for Bezier<P> {
+impl<P: Point> CubicGenerator<P> for CubicBezier<P> {
     #[inline]
     fn to_curve(&self) -> CubicCurve<P> {
         let char_matrix = [
@@ -337,7 +337,7 @@ impl CubicSegment<Vec2> {
     /// example, the ubiquitous "ease-in-out" is defined as `(0.25, 0.1), (0.25, 1.0)`.
     pub fn new_bezier(p1: impl Into<Vec2>, p2: impl Into<Vec2>) -> Self {
         let (p0, p3) = (Vec2::ZERO, Vec2::ONE);
-        let bezier = Bezier::new([[p0, p1.into(), p2.into(), p3]]).to_curve();
+        let bezier = CubicBezier::new([[p0, p1.into(), p2.into(), p3]]).to_curve();
         bezier.segments[0].clone()
     }
 
@@ -550,7 +550,7 @@ impl<P: Point> CubicCurve<P> {
 mod tests {
     use glam::{vec2, Vec2};
 
-    use crate::cubic_splines::{Bezier, CubicGenerator, CubicSegment};
+    use crate::cubic_splines::{CubicBezier, CubicGenerator, CubicSegment};
 
     /// How close two floats can be and still be considered equal
     const FLOAT_EQ: f32 = 1e-5;
@@ -565,7 +565,7 @@ mod tests {
             vec2(5.0, 3.0),
             vec2(9.0, 8.0),
         ]];
-        let bezier = Bezier::new(points).to_curve();
+        let bezier = CubicBezier::new(points).to_curve();
         for i in 0..=N_SAMPLES {
             let t = i as f32 / N_SAMPLES as f32; // Check along entire length
             assert!(bezier.position(t).distance(cubic_manual(t, points[0])) <= FLOAT_EQ);

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -20,7 +20,9 @@ pub use rects::*;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        cubic_splines::{BSpline, Bezier, CardinalSpline, CubicGenerator, CubicSegment, Hermite},
+        cubic_splines::{
+            BSpline, CardinalSpline, CubicBezier, CubicGenerator, CubicSegment, Hermite,
+        },
         BVec2, BVec3, BVec4, EulerRot, IRect, IVec2, IVec3, IVec4, Mat2, Mat3, Mat4, Quat, Ray,
         Rect, URect, UVec2, UVec3, UVec4, Vec2, Vec2Swizzles, Vec3, Vec3Swizzles, Vec4,
         Vec4Swizzles,

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -27,6 +27,7 @@ bevy_derive = { path = "../bevy_derive", version = "0.12.0-dev" }
 
 # other
 bitflags = "2.3"
+fixedbitset = "0.4"
 # direct dependency required for derive macro
 bytemuck = { version = "1", features = ["derive"] }
 naga_oil = "0.8"

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -56,14 +56,10 @@ use bevy_asset::{load_internal_asset, AddAsset, Assets, Handle, HandleUntyped};
 use bevy_ecs::prelude::*;
 use bevy_reflect::TypeUuid;
 use bevy_render::{
-    camera::CameraUpdateSystem,
-    extract_resource::ExtractResourcePlugin,
-    prelude::Color,
-    render_graph::RenderGraph,
-    render_phase::sort_phase_system,
-    render_resource::Shader,
-    view::{ViewSet, VisibilitySystems},
-    ExtractSchedule, Render, RenderApp, RenderSet,
+    camera::CameraUpdateSystem, extract_resource::ExtractResourcePlugin, prelude::Color,
+    render_asset::prepare_assets, render_graph::RenderGraph, render_phase::sort_phase_system,
+    render_resource::Shader, texture::Image, view::VisibilitySystems, ExtractSchedule, Render,
+    RenderApp, RenderSet,
 };
 use bevy_transform::TransformSystem;
 use environment_map::EnvironmentMapPlugin;
@@ -269,37 +265,18 @@ impl Plugin for PbrPlugin {
 
         // Extract the required data from the main world
         render_app
-            .configure_sets(
-                Render,
-                (
-                    RenderLightSystems::PrepareLights.in_set(RenderSet::Prepare),
-                    RenderLightSystems::PrepareClusters.in_set(RenderSet::Prepare),
-                    RenderLightSystems::QueueShadows.in_set(RenderSet::Queue),
-                ),
-            )
             .add_systems(
                 ExtractSchedule,
-                (
-                    render::extract_clusters.in_set(RenderLightSystems::ExtractClusters),
-                    render::extract_lights.in_set(RenderLightSystems::ExtractLights),
-                ),
+                (render::extract_clusters, render::extract_lights),
             )
             .add_systems(
                 Render,
                 (
                     render::prepare_lights
-                        .before(ViewSet::PrepareUniforms)
-                        .in_set(RenderLightSystems::PrepareLights),
-                    // A sync is needed after prepare_lights, before prepare_view_uniforms,
-                    // because prepare_lights creates new views for shadow mapping
-                    apply_deferred
-                        .in_set(RenderSet::Prepare)
-                        .after(RenderLightSystems::PrepareLights)
-                        .before(ViewSet::PrepareUniforms),
-                    render::prepare_clusters
-                        .after(render::prepare_lights)
-                        .in_set(RenderLightSystems::PrepareClusters),
+                        .in_set(RenderSet::ManageViews)
+                        .after(prepare_assets::<Image>),
                     sort_phase_system::<Shadow>.in_set(RenderSet::PhaseSort),
+                    render::prepare_clusters.in_set(RenderSet::PrepareResources),
                 ),
             )
             .init_resource::<LightMeta>();

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -1,7 +1,7 @@
 use crate::{
     render, AlphaMode, DrawMesh, DrawPrepass, EnvironmentMapLight, MeshPipeline, MeshPipelineKey,
-    MeshTransforms, MeshUniform, PrepassPipelinePlugin, PrepassPlugin, RenderLightSystems,
-    ScreenSpaceAmbientOcclusionSettings, SetMeshBindGroup, SetMeshViewBindGroup, Shadow,
+    MeshTransforms, PrepassPipelinePlugin, PrepassPlugin, ScreenSpaceAmbientOcclusionSettings,
+    SetMeshBindGroup, SetMeshViewBindGroup, Shadow,
 };
 use bevy_app::{App, Plugin};
 use bevy_asset::{AddAsset, AssetEvent, AssetServer, Assets, Handle};
@@ -24,15 +24,15 @@ use bevy_render::{
     extract_component::ExtractComponentPlugin,
     mesh::{Mesh, MeshVertexBufferLayout},
     prelude::Image,
-    render_asset::{PrepareAssetSet, RenderAssets},
+    render_asset::{prepare_assets, RenderAssets},
     render_phase::{
         AddRenderCommand, DrawFunctions, PhaseItem, RenderCommand, RenderCommandResult,
         RenderPhase, SetItemPipeline, TrackedRenderPass,
     },
     render_resource::{
-        AsBindGroup, AsBindGroupError, BindGroup, BindGroupLayout, GpuArrayBufferIndex,
-        OwnedBindingResource, PipelineCache, RenderPipelineDescriptor, Shader, ShaderRef,
-        SpecializedMeshPipeline, SpecializedMeshPipelineError, SpecializedMeshPipelines,
+        AsBindGroup, AsBindGroupError, BindGroup, BindGroupLayout, OwnedBindingResource,
+        PipelineCache, RenderPipelineDescriptor, Shader, ShaderRef, SpecializedMeshPipeline,
+        SpecializedMeshPipelineError, SpecializedMeshPipelines,
     },
     renderer::RenderDevice,
     texture::FallbackImage,
@@ -205,10 +205,14 @@ where
                     Render,
                     (
                         prepare_materials::<M>
-                            .in_set(RenderSet::Prepare)
-                            .after(PrepareAssetSet::PreAssetPrepare),
-                        render::queue_shadows::<M>.in_set(RenderLightSystems::QueueShadows),
-                        queue_material_meshes::<M>.in_set(RenderSet::Queue),
+                            .in_set(RenderSet::PrepareAssets)
+                            .after(prepare_assets::<Image>),
+                        render::queue_shadows::<M>
+                            .in_set(RenderSet::QueueMeshes)
+                            .after(prepare_materials::<M>),
+                        queue_material_meshes::<M>
+                            .in_set(RenderSet::QueueMeshes)
+                            .after(prepare_materials::<M>),
                     ),
                 );
         }
@@ -379,12 +383,7 @@ pub fn queue_material_meshes<M: Material>(
     msaa: Res<Msaa>,
     render_meshes: Res<RenderAssets<Mesh>>,
     render_materials: Res<RenderMaterials<M>>,
-    material_meshes: Query<(
-        &Handle<M>,
-        &Handle<Mesh>,
-        &MeshTransforms,
-        &GpuArrayBufferIndex<MeshUniform>,
-    )>,
+    material_meshes: Query<(&Handle<M>, &Handle<Mesh>, &MeshTransforms)>,
     images: Res<RenderAssets<Image>>,
     mut views: Query<(
         &ExtractedView,
@@ -468,7 +467,7 @@ pub fn queue_material_meshes<M: Material>(
 
         let rangefinder = view.rangefinder3d();
         for visible_entity in &visible_entities.entities {
-            if let Ok((material_handle, mesh_handle, mesh_transforms, batch_indices)) =
+            if let Ok((material_handle, mesh_handle, mesh_transforms)) =
                 material_meshes.get(*visible_entity)
             {
                 if let (Some(mesh), Some(material)) = (
@@ -526,9 +525,7 @@ pub fn queue_material_meshes<M: Material>(
                                 draw_function: draw_opaque_pbr,
                                 pipeline: pipeline_id,
                                 distance,
-                                per_object_binding_dynamic_offset: batch_indices
-                                    .dynamic_offset
-                                    .unwrap_or_default(),
+                                batch_size: 1,
                             });
                         }
                         AlphaMode::Mask(_) => {
@@ -537,9 +534,7 @@ pub fn queue_material_meshes<M: Material>(
                                 draw_function: draw_alpha_mask_pbr,
                                 pipeline: pipeline_id,
                                 distance,
-                                per_object_binding_dynamic_offset: batch_indices
-                                    .dynamic_offset
-                                    .unwrap_or_default(),
+                                batch_size: 1,
                             });
                         }
                         AlphaMode::Blend
@@ -551,6 +546,7 @@ pub fn queue_material_meshes<M: Material>(
                                 draw_function: draw_transparent_pbr,
                                 pipeline: pipeline_id,
                                 distance,
+                                batch_size: 1,
                             });
                         }
                     }

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -809,7 +809,9 @@ pub fn queue_prepass_material_meshes<M: Material>(
         let rangefinder = view.rangefinder3d();
 
         for visible_entity in &visible_entities.entities {
-            let Ok((material_handle, mesh_handle, mesh_transforms, batch_indices)) = material_meshes.get(*visible_entity) else {
+            let Ok((material_handle, mesh_handle, mesh_transforms, batch_indices)) =
+                material_meshes.get(*visible_entity)
+            else {
                 continue;
             };
 

--- a/crates/bevy_pbr/src/render/fog.rs
+++ b/crates/bevy_pbr/src/render/fog.rs
@@ -113,12 +113,6 @@ pub fn prepare_fog(
         .write_buffer(&render_device, &render_queue);
 }
 
-/// Labels for fog-related systems
-#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
-pub enum RenderFogSystems {
-    PrepareFog,
-}
-
 /// Inserted on each `Entity` with an `ExtractedView` to keep track of its offset
 /// in the `gpu_fogs` `DynamicUniformBuffer` within `FogMeta`
 #[derive(Component)]
@@ -143,11 +137,7 @@ impl Plugin for FogPlugin {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
                 .init_resource::<FogMeta>()
-                .add_systems(Render, prepare_fog.in_set(RenderFogSystems::PrepareFog))
-                .configure_set(
-                    Render,
-                    RenderFogSystems::PrepareFog.in_set(RenderSet::Prepare),
-                );
+                .add_systems(Render, prepare_fog.in_set(RenderSet::PrepareResources));
         }
     }
 }

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -3,8 +3,8 @@ use crate::{
     CascadeShadowConfig, Cascades, CascadesVisibleEntities, Clusters, CubemapVisibleEntities,
     DirectionalLight, DirectionalLightShadowMap, DrawPrepass, EnvironmentMapLight,
     GlobalVisiblePointLights, Material, MaterialPipelineKey, MeshPipeline, MeshPipelineKey,
-    MeshUniform, NotShadowCaster, PointLight, PointLightShadowMap, PrepassPipeline,
-    RenderMaterials, SpotLight, VisiblePointLights,
+    NotShadowCaster, PointLight, PointLightShadowMap, PrepassPipeline, RenderMaterials, SpotLight,
+    VisiblePointLights,
 };
 use bevy_asset::Handle;
 use bevy_core_pipeline::core_3d::Transparent3d;
@@ -31,15 +31,6 @@ use bevy_utils::{
     HashMap,
 };
 use std::{hash::Hash, num::NonZeroU64};
-
-#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
-pub enum RenderLightSystems {
-    ExtractClusters,
-    ExtractLights,
-    PrepareClusters,
-    PrepareLights,
-    QueueShadows,
-}
 
 #[derive(Component)]
 pub struct ExtractedPointLight {
@@ -1556,10 +1547,7 @@ pub fn prepare_clusters(
 pub fn queue_shadows<M: Material>(
     shadow_draw_functions: Res<DrawFunctions<Shadow>>,
     prepass_pipeline: Res<PrepassPipeline<M>>,
-    casting_meshes: Query<
-        (&GpuArrayBufferIndex<MeshUniform>, &Handle<Mesh>, &Handle<M>),
-        Without<NotShadowCaster>,
-    >,
+    casting_meshes: Query<(&Handle<Mesh>, &Handle<M>), Without<NotShadowCaster>>,
     render_meshes: Res<RenderAssets<Mesh>>,
     render_materials: Res<RenderMaterials<M>>,
     mut pipelines: ResMut<SpecializedMeshPipelines<PrepassPipeline<M>>>,
@@ -1604,9 +1592,7 @@ pub fn queue_shadows<M: Material>(
             // NOTE: Lights with shadow mapping disabled will have no visible entities
             // so no meshes will be queued
             for entity in visible_entities.iter().copied() {
-                if let Ok((batch_indices, mesh_handle, material_handle)) =
-                    casting_meshes.get(entity)
-                {
+                if let Ok((mesh_handle, material_handle)) = casting_meshes.get(entity) {
                     if let (Some(mesh), Some(material)) = (
                         render_meshes.get(mesh_handle),
                         render_materials.get(material_handle),
@@ -1653,9 +1639,6 @@ pub fn queue_shadows<M: Material>(
                             pipeline: pipeline_id,
                             entity,
                             distance: 0.0, // TODO: sort front-to-back
-                            per_object_binding_dynamic_offset: batch_indices
-                                .dynamic_offset
-                                .unwrap_or_default(),
                         });
                     }
                 }
@@ -1666,16 +1649,13 @@ pub fn queue_shadows<M: Material>(
 
 pub struct Shadow {
     pub distance: f32,
-    // Per-object data may be bound at different dynamic offsets within a buffer. If it is, then
-    // each batch of per-object data starts at the same dynamic offset.
-    pub per_object_binding_dynamic_offset: u32,
     pub entity: Entity,
     pub pipeline: CachedRenderPipelineId,
     pub draw_function: DrawFunctionId,
 }
 
 impl PhaseItem for Shadow {
-    type SortKey = (usize, u32);
+    type SortKey = usize;
 
     #[inline]
     fn entity(&self) -> Entity {
@@ -1684,7 +1664,7 @@ impl PhaseItem for Shadow {
 
     #[inline]
     fn sort_key(&self) -> Self::SortKey {
-        (self.pipeline.id(), self.per_object_binding_dynamic_offset)
+        self.pipeline.id()
     }
 
     #[inline]

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -52,7 +52,8 @@ use crate::render::{
 #[derive(Default)]
 pub struct MeshRenderPlugin;
 
-const MAX_JOINTS: usize = 256;
+/// Maximum number of joints supported for skinned meshes.
+pub const MAX_JOINTS: usize = 256;
 const JOINT_SIZE: usize = std::mem::size_of::<Mat4>();
 pub(crate) const JOINT_BUFFER_SIZE: usize = MAX_JOINTS * JOINT_SIZE;
 
@@ -323,6 +324,7 @@ impl SkinnedMeshJoints {
             joints
                 .iter_many(&skin.joints)
                 .zip(inverse_bindposes.iter())
+                .take(MAX_JOINTS)
                 .map(|(joint, bindpose)| joint.affine() * *bindpose),
         );
         // iter_many will skip any failed fetches. This will cause it to assign the wrong bones,

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -86,7 +86,9 @@ impl Plugin for ScreenSpaceAmbientOcclusionPlugin {
     }
 
     fn finish(&self, app: &mut App) {
-        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
 
         if !render_app
             .world
@@ -226,7 +228,8 @@ impl ViewNode for SsaoNode {
             pipeline_cache.get_compute_pipeline(pipelines.preprocess_depth_pipeline),
             pipeline_cache.get_compute_pipeline(pipelines.spatial_denoise_pipeline),
             pipeline_cache.get_compute_pipeline(pipeline_id.0),
-        ) else {
+        )
+        else {
             return Ok(());
         };
 
@@ -640,7 +643,9 @@ fn prepare_ssao_textures(
     views: Query<(Entity, &ExtractedCamera), With<ScreenSpaceAmbientOcclusionSettings>>,
 ) {
     for (entity, camera) in &views {
-        let Some(physical_viewport_size) = camera.physical_viewport_size else { continue };
+        let Some(physical_viewport_size) = camera.physical_viewport_size else {
+            continue;
+        };
         let size = Extent3d {
             width: physical_viewport_size.x,
             height: physical_viewport_size.y,

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -116,9 +116,14 @@ impl Plugin for ScreenSpaceAmbientOcclusionPlugin {
             .init_resource::<SsaoPipelines>()
             .init_resource::<SpecializedComputePipelines<SsaoPipelines>>()
             .add_systems(ExtractSchedule, extract_ssao_settings)
-            .add_systems(Render, prepare_ssao_textures.in_set(RenderSet::Prepare))
-            .add_systems(Render, prepare_ssao_pipelines.in_set(RenderSet::Prepare))
-            .add_systems(Render, queue_ssao_bind_groups.in_set(RenderSet::Queue))
+            .add_systems(
+                Render,
+                (
+                    prepare_ssao_pipelines.in_set(RenderSet::Prepare),
+                    prepare_ssao_textures.in_set(RenderSet::PrepareResources),
+                    prepare_ssao_bind_groups.in_set(RenderSet::PrepareBindGroups),
+                ),
+            )
             .add_render_graph_node::<ViewNodeRunner<SsaoNode>>(
                 CORE_3D,
                 draw_3d_graph::node::SCREEN_SPACE_AMBIENT_OCCLUSION,
@@ -755,7 +760,7 @@ struct SsaoBindGroups {
     spatial_denoise_bind_group: BindGroup,
 }
 
-fn queue_ssao_bind_groups(
+fn prepare_ssao_bind_groups(
     mut commands: Commands,
     render_device: Res<RenderDevice>,
     pipelines: Res<SsaoPipelines>,

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -1,4 +1,4 @@
-use crate::{DrawMesh, MeshPipelineKey, MeshUniform, SetMeshBindGroup, SetMeshViewBindGroup};
+use crate::{DrawMesh, MeshPipelineKey, SetMeshBindGroup, SetMeshViewBindGroup};
 use crate::{MeshPipeline, MeshTransforms};
 use bevy_app::Plugin;
 use bevy_asset::{load_internal_asset, Handle, HandleUntyped};
@@ -7,7 +7,6 @@ use bevy_ecs::{prelude::*, reflect::ReflectComponent};
 use bevy_reflect::std_traits::ReflectDefault;
 use bevy_reflect::{Reflect, TypeUuid};
 use bevy_render::extract_component::{ExtractComponent, ExtractComponentPlugin};
-use bevy_render::render_resource::GpuArrayBufferIndex;
 use bevy_render::Render;
 use bevy_render::{
     extract_resource::{ExtractResource, ExtractResourcePlugin},
@@ -50,7 +49,7 @@ impl Plugin for WireframePlugin {
             render_app
                 .add_render_command::<Opaque3d, DrawWireframes>()
                 .init_resource::<SpecializedMeshPipelines<WireframePipeline>>()
-                .add_systems(Render, queue_wireframes.in_set(RenderSet::Queue));
+                .add_systems(Render, queue_wireframes.in_set(RenderSet::QueueMeshes));
         }
     }
 
@@ -118,21 +117,8 @@ fn queue_wireframes(
     pipeline_cache: Res<PipelineCache>,
     msaa: Res<Msaa>,
     mut material_meshes: ParamSet<(
-        Query<(
-            Entity,
-            &Handle<Mesh>,
-            &MeshTransforms,
-            &GpuArrayBufferIndex<MeshUniform>,
-        )>,
-        Query<
-            (
-                Entity,
-                &Handle<Mesh>,
-                &MeshTransforms,
-                &GpuArrayBufferIndex<MeshUniform>,
-            ),
-            With<Wireframe>,
-        >,
+        Query<(Entity, &Handle<Mesh>, &MeshTransforms)>,
+        Query<(Entity, &Handle<Mesh>, &MeshTransforms), With<Wireframe>>,
     )>,
     mut views: Query<(&ExtractedView, &VisibleEntities, &mut RenderPhase<Opaque3d>)>,
 ) {
@@ -142,36 +128,34 @@ fn queue_wireframes(
         let rangefinder = view.rangefinder3d();
 
         let view_key = msaa_key | MeshPipelineKey::from_hdr(view.hdr);
-        let add_render_phase = |(entity, mesh_handle, mesh_transforms, batch_indices): (
-            Entity,
-            &Handle<Mesh>,
-            &MeshTransforms,
-            &GpuArrayBufferIndex<MeshUniform>,
-        )| {
-            if let Some(mesh) = render_meshes.get(mesh_handle) {
-                let key =
-                    view_key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
-                let pipeline_id =
-                    pipelines.specialize(&pipeline_cache, &wireframe_pipeline, key, &mesh.layout);
-                let pipeline_id = match pipeline_id {
-                    Ok(id) => id,
-                    Err(err) => {
-                        error!("{}", err);
-                        return;
-                    }
-                };
-                opaque_phase.add(Opaque3d {
-                    entity,
-                    pipeline: pipeline_id,
-                    draw_function: draw_custom,
-                    distance: rangefinder
-                        .distance_translation(&mesh_transforms.transform.translation),
-                    per_object_binding_dynamic_offset: batch_indices
-                        .dynamic_offset
-                        .unwrap_or_default(),
-                });
-            }
-        };
+        let add_render_phase =
+            |(entity, mesh_handle, mesh_transforms): (Entity, &Handle<Mesh>, &MeshTransforms)| {
+                if let Some(mesh) = render_meshes.get(mesh_handle) {
+                    let key = view_key
+                        | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
+                    let pipeline_id = pipelines.specialize(
+                        &pipeline_cache,
+                        &wireframe_pipeline,
+                        key,
+                        &mesh.layout,
+                    );
+                    let pipeline_id = match pipeline_id {
+                        Ok(id) => id,
+                        Err(err) => {
+                            error!("{}", err);
+                            return;
+                        }
+                    };
+                    opaque_phase.add(Opaque3d {
+                        entity,
+                        pipeline: pipeline_id,
+                        draw_function: draw_custom,
+                        distance: rangefinder
+                            .distance_translation(&mesh_transforms.transform.translation),
+                        batch_size: 1,
+                    });
+                }
+            };
 
         if wireframe_config.global {
             let query = material_meshes.p0();

--- a/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
@@ -195,7 +195,8 @@ impl<'a> ReflectDerive<'a> {
                     let syn::Expr::Lit(syn::ExprLit {
                         lit: syn::Lit::Str(lit),
                         ..
-                    }) = &pair.value else {
+                    }) = &pair.value
+                    else {
                         return Err(syn::Error::new(
                             pair.span(),
                             format_args!("`#[{TYPE_PATH_ATTRIBUTE_NAME} = \"...\"]` must be a string literal"),
@@ -211,7 +212,8 @@ impl<'a> ReflectDerive<'a> {
                     let syn::Expr::Lit(syn::ExprLit {
                         lit: syn::Lit::Str(lit),
                         ..
-                    }) = &pair.value else {
+                    }) = &pair.value
+                    else {
                         return Err(syn::Error::new(
                             pair.span(),
                             format_args!("`#[{TYPE_NAME_ATTRIBUTE_NAME} = \"...\"]` must be a string literal"),

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -513,8 +513,8 @@ pub mod prelude {
     pub use crate::std_traits::*;
     #[doc(hidden)]
     pub use crate::{
-        reflect_trait, FromReflect, GetField, GetTupleStructField, Reflect, ReflectDeserialize,
-        ReflectFromReflect, ReflectSerialize, Struct, TupleStruct,
+        reflect_trait, FromReflect, GetField, GetPath, GetTupleStructField, Reflect,
+        ReflectDeserialize, ReflectFromReflect, ReflectPath, ReflectSerialize, Struct, TupleStruct,
     };
 }
 

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -513,7 +513,7 @@ mod tests {
 
     #[test]
     fn test_into_iter() {
-        let expected = vec!["foo", "bar", "baz"];
+        let expected = ["foo", "bar", "baz"];
 
         let mut map = DynamicMap::default();
         map.insert(0usize, expected[0].to_string());

--- a/crates/bevy_reflect/src/path/mod.rs
+++ b/crates/bevy_reflect/src/path/mod.rs
@@ -400,12 +400,12 @@ mod tests {
     #[derive(Reflect)]
     struct B {
         foo: usize,
-        bar: C,
+        łørđ: C,
     }
 
     #[derive(Reflect)]
     struct C {
-        baz: f32,
+        mосква: f32,
     }
 
     #[derive(Reflect)]
@@ -418,7 +418,7 @@ mod tests {
     enum F {
         Unit,
         Tuple(u32, u32),
-        Struct { value: char },
+        Şķràźÿ { 東京: char },
     }
 
     fn a_sample() -> A {
@@ -426,13 +426,13 @@ mod tests {
             w: 1,
             x: B {
                 foo: 10,
-                bar: C { baz: 3.14 },
+                łørđ: C { mосква: 3.14 },
             },
-            y: vec![C { baz: 1.0 }, C { baz: 2.0 }],
+            y: vec![C { mосква: 1.0 }, C { mосква: 2.0 }],
             z: D(E(10.0, 42)),
             unit_variant: F::Unit,
             tuple_variant: F::Tuple(123, 321),
-            struct_variant: F::Struct { value: 'm' },
+            struct_variant: F::Şķràźÿ { 東京: 'm' },
             array: [86, 75, 309],
             tuple: (true, 1.23),
         }
@@ -460,19 +460,19 @@ mod tests {
             &[(access_field("x"), 1), (access_field("foo"), 2)]
         );
         assert_eq!(
-            &*ParsedPath::parse("x.bar.baz").unwrap().0,
+            &*ParsedPath::parse("x.łørđ.mосква").unwrap().0,
             &[
                 (access_field("x"), 1),
-                (access_field("bar"), 2),
-                (access_field("baz"), 6)
+                (access_field("łørđ"), 2),
+                (access_field("mосква"), 10)
             ]
         );
         assert_eq!(
-            &*ParsedPath::parse("y[1].baz").unwrap().0,
+            &*ParsedPath::parse("y[1].mосква").unwrap().0,
             &[
                 (access_field("y"), 1),
                 (Access::ListIndex(1), 2),
-                (access_field("baz"), 5)
+                (access_field("mосква"), 5)
             ]
         );
         assert_eq!(
@@ -503,14 +503,14 @@ mod tests {
 
         let b = ParsedPath::parse("w").unwrap();
         let c = ParsedPath::parse("x.foo").unwrap();
-        let d = ParsedPath::parse("x.bar.baz").unwrap();
-        let e = ParsedPath::parse("y[1].baz").unwrap();
+        let d = ParsedPath::parse("x.łørđ.mосква").unwrap();
+        let e = ParsedPath::parse("y[1].mосква").unwrap();
         let f = ParsedPath::parse("z.0.1").unwrap();
         let g = ParsedPath::parse("x#0").unwrap();
         let h = ParsedPath::parse("x#1#0").unwrap();
         let i = ParsedPath::parse("unit_variant").unwrap();
         let j = ParsedPath::parse("tuple_variant.1").unwrap();
-        let k = ParsedPath::parse("struct_variant.value").unwrap();
+        let k = ParsedPath::parse("struct_variant.東京").unwrap();
         let l = ParsedPath::parse("struct_variant#0").unwrap();
         let m = ParsedPath::parse("array[2]").unwrap();
         let n = ParsedPath::parse("tuple.1").unwrap();
@@ -580,15 +580,15 @@ mod tests {
 
         assert_eq!(*a.path::<usize>("w").unwrap(), 1);
         assert_eq!(*a.path::<usize>("x.foo").unwrap(), 10);
-        assert_eq!(*a.path::<f32>("x.bar.baz").unwrap(), 3.14);
-        assert_eq!(*a.path::<f32>("y[1].baz").unwrap(), 2.0);
+        assert_eq!(*a.path::<f32>("x.łørđ.mосква").unwrap(), 3.14);
+        assert_eq!(*a.path::<f32>("y[1].mосква").unwrap(), 2.0);
         assert_eq!(*a.path::<usize>("z.0.1").unwrap(), 42);
         assert_eq!(*a.path::<usize>("x#0").unwrap(), 10);
         assert_eq!(*a.path::<f32>("x#1#0").unwrap(), 3.14);
 
         assert_eq!(*a.path::<F>("unit_variant").unwrap(), F::Unit);
         assert_eq!(*a.path::<u32>("tuple_variant.1").unwrap(), 321);
-        assert_eq!(*a.path::<char>("struct_variant.value").unwrap(), 'm');
+        assert_eq!(*a.path::<char>("struct_variant.東京").unwrap(), 'm');
         assert_eq!(*a.path::<char>("struct_variant#0").unwrap(), 'm');
 
         assert_eq!(*a.path::<i32>("array[2]").unwrap(), 309);
@@ -597,8 +597,8 @@ mod tests {
         *a.path_mut::<f32>("tuple.1").unwrap() = 3.21;
         assert_eq!(*a.path::<f32>("tuple.1").unwrap(), 3.21);
 
-        *a.path_mut::<f32>("y[1].baz").unwrap() = 3.0;
-        assert_eq!(a.y[1].baz, 3.0);
+        *a.path_mut::<f32>("y[1].mосква").unwrap() = 3.0;
+        assert_eq!(a.y[1].mосква, 3.0);
 
         *a.path_mut::<u32>("tuple_variant.0").unwrap() = 1337;
         assert_eq!(a.tuple_variant, F::Tuple(1337, 321));
@@ -649,8 +649,8 @@ mod tests {
             &[(Access::TupleIndex(5), 1)]
         );
         assert_eq!(
-            &*ParsedPath::parse("[0].bar").unwrap().0,
-            &[(Access::ListIndex(0), 1), (access_field("bar"), 4)]
+            &*ParsedPath::parse("[0].łørđ").unwrap().0,
+            &[(Access::ListIndex(0), 1), (access_field("łørđ"), 4)]
         );
     }
 }

--- a/crates/bevy_reflect/src/path/parse.rs
+++ b/crates/bevy_reflect/src/path/parse.rs
@@ -1,4 +1,4 @@
-use std::{fmt, num::ParseIntError};
+use std::{fmt, num::ParseIntError, str::from_utf8_unchecked};
 
 use thiserror::Error;
 
@@ -33,28 +33,37 @@ enum Error<'a> {
 
 pub(super) struct PathParser<'a> {
     path: &'a str,
-    offset: usize,
+    remaining: &'a [u8],
 }
 impl<'a> PathParser<'a> {
     pub(super) fn new(path: &'a str) -> Self {
-        PathParser { path, offset: 0 }
+        let remaining = path.as_bytes();
+        PathParser { path, remaining }
     }
 
     fn next_token(&mut self) -> Option<Token<'a>> {
-        let input = &self.path[self.offset..];
+        let to_parse = self.remaining;
 
         // Return with `None` if empty.
-        let first_char = input.chars().next()?;
+        let (first_byte, remaining) = to_parse.split_first()?;
 
-        if let Some(token) = Token::symbol_from_char(first_char) {
-            self.offset += 1; // NOTE: we assume all symbols are ASCII
+        if let Some(token) = Token::symbol_from_byte(*first_byte) {
+            self.remaining = remaining; // NOTE: all symbols are ASCII
             return Some(token);
         }
         // We are parsing either `0123` or `field`.
         // If we do not find a subsequent token, we are at the end of the parse string.
-        let ident = input.split_once(Token::SYMBOLS).map_or(input, |t| t.0);
+        let ident_len = to_parse.iter().position(|t| Token::SYMBOLS.contains(t));
+        let (ident, remaining) = to_parse.split_at(ident_len.unwrap_or(to_parse.len()));
+        // SAFETY: This relies on `self.remaining` always remaining valid UTF8:
+        // - self.remaining is a slice derived from self.path (valid &str)
+        // - The slice's end is either the same as the valid &str or
+        //   the last byte before an ASCII utf-8 character (ie: it is a char
+        //   boundary).
+        // - The slice always starts after a symbol ie: an ASCII character's boundary.
+        let ident = unsafe { from_utf8_unchecked(ident) };
 
-        self.offset += ident.len();
+        self.remaining = remaining;
         Some(Token::Ident(Ident(ident)))
     }
 
@@ -82,13 +91,17 @@ impl<'a> PathParser<'a> {
             }
         }
     }
+
+    fn offset(&self) -> usize {
+        self.path.len() - self.remaining.len()
+    }
 }
 impl<'a> Iterator for PathParser<'a> {
     type Item = (Result<Access<'a>, ReflectPathError<'a>>, usize);
 
     fn next(&mut self) -> Option<Self::Item> {
         let token = self.next_token()?;
-        let offset = self.offset;
+        let offset = self.offset();
         let err = |error| ReflectPathError::ParseError {
             offset,
             path: self.path,
@@ -114,33 +127,38 @@ impl<'a> Ident<'a> {
     }
 }
 
+// NOTE: We use repr(u8) so that the `match byte` in `Token::symbol_from_byte`
+// becomes a "check `byte` is one of SYMBOLS and forward its value" this makes
+// the optimizer happy, and shaves off a few cycles.
 #[derive(Debug, PartialEq, Eq)]
+#[repr(u8)]
 enum Token<'a> {
-    Dot,
-    Pound,
-    OpenBracket,
-    CloseBracket,
+    Dot = b'.',
+    Pound = b'#',
+    OpenBracket = b'[',
+    CloseBracket = b']',
     Ident(Ident<'a>),
 }
 impl fmt::Display for Token<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Token::Dot => f.write_str("."),
-            Token::Pound => f.write_str("#"),
-            Token::OpenBracket => f.write_str("["),
-            Token::CloseBracket => f.write_str("]"),
-            Token::Ident(ident) => f.write_str(ident.0),
-        }
+        let text = match self {
+            Token::Dot => ".",
+            Token::Pound => "#",
+            Token::OpenBracket => "[",
+            Token::CloseBracket => "]",
+            Token::Ident(ident) => ident.0,
+        };
+        f.write_str(text)
     }
 }
 impl<'a> Token<'a> {
-    const SYMBOLS: &[char] = &['.', '#', '[', ']'];
-    fn symbol_from_char(char: char) -> Option<Self> {
-        match char {
-            '.' => Some(Self::Dot),
-            '#' => Some(Self::Pound),
-            '[' => Some(Self::OpenBracket),
-            ']' => Some(Self::CloseBracket),
+    const SYMBOLS: &[u8] = b".#[]";
+    fn symbol_from_byte(byte: u8) -> Option<Self> {
+        match byte {
+            b'.' => Some(Self::Dot),
+            b'#' => Some(Self::Pound),
+            b'[' => Some(Self::OpenBracket),
+            b']' => Some(Self::CloseBracket),
             _ => None,
         }
     }

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -507,7 +507,7 @@ impl Debug for DynamicStruct {
 /// Returns [`None`] if the comparison couldn't even be performed.
 #[inline]
 pub fn struct_partial_eq<S: Struct>(a: &S, b: &dyn Reflect) -> Option<bool> {
-    let ReflectRef::Struct(struct_value) = b.reflect_ref()  else {
+    let ReflectRef::Struct(struct_value) = b.reflect_ref() else {
         return Some(false);
     };
 

--- a/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/generics.fail.stderr
+++ b/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/generics.fail.stderr
@@ -11,14 +11,14 @@ error[E0277]: the trait bound `NoReflect: Reflect` is not satisfied
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Reflect` is not implemented for `NoReflect`
    |
    = help: the following other types implement trait `Reflect`:
-             &'static Path
-             ()
-             (A, B)
-             (A, B, C)
-             (A, B, C, D)
-             (A, B, C, D, E)
-             (A, B, C, D, E, F)
-             (A, B, C, D, E, F, G)
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
            and $N others
 note: required for `Foo<NoReflect>` to implement `Reflect`
   --> tests/reflect_derive/generics.fail.rs:3:10

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -39,7 +39,7 @@ impl Plugin for CameraPlugin {
             render_app
                 .init_resource::<SortedCameras>()
                 .add_systems(ExtractSchedule, extract_cameras)
-                .add_systems(Render, sort_cameras.in_set(RenderSet::Prepare));
+                .add_systems(Render, sort_cameras.in_set(RenderSet::ManageViews));
             let camera_driver_node = CameraDriverNode::new(&mut render_app.world);
             let mut render_graph = render_app.world.resource_mut::<RenderGraph>();
             render_graph.add_node(crate::main_graph::node::CAMERA_DRIVER, camera_driver_node);

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -197,6 +197,8 @@ pub enum ScalingMode {
 ///
 /// Note that the scale of the projection and the apparent size of objects are inversely proportional.
 /// As the size of the projection increases, the size of objects decreases.
+///
+/// Note also that the view frustum is centered at the origin.
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Default)]
 pub struct OrthographicProjection {
@@ -204,7 +206,7 @@ pub struct OrthographicProjection {
     ///
     /// Objects closer than this will not be rendered.
     ///
-    /// Defaults to `0.0`
+    /// Defaults to `-1000.0`
     pub near: f32,
     /// The distance of the far clipping plane in world units.
     ///
@@ -315,7 +317,7 @@ impl Default for OrthographicProjection {
     fn default() -> Self {
         OrthographicProjection {
             scale: 1.0,
-            near: 0.0,
+            near: -1000.0,
             far: 1000.0,
             viewport_origin: Vec2::new(0.5, 0.5),
             scaling_mode: ScalingMode::WindowSize(1.0),

--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -1990,8 +1990,14 @@ mod tests {
         let hsla = Color::hsla(0., 0., 0., 0.);
         let lcha = Color::lcha(0., 0., 0., 0.);
         assert_eq!(rgba_l, rgba_l.as_rgba_linear());
-        let Color::RgbaLinear { .. } = rgba.as_rgba_linear() else { panic!("from Rgba") };
-        let Color::RgbaLinear { .. } = hsla.as_rgba_linear() else { panic!("from Hsla") };
-        let Color::RgbaLinear { .. } = lcha.as_rgba_linear() else { panic!("from Lcha") };
+        let Color::RgbaLinear { .. } = rgba.as_rgba_linear() else {
+            panic!("from Rgba")
+        };
+        let Color::RgbaLinear { .. } = hsla.as_rgba_linear() else {
+            panic!("from Hsla")
+        };
+        let Color::RgbaLinear { .. } = lcha.as_rgba_linear() else {
+            panic!("from Lcha")
+        };
     }
 }

--- a/crates/bevy_render/src/extract_component.rs
+++ b/crates/bevy_render/src/extract_component.rs
@@ -85,7 +85,7 @@ impl<C: Component + ShaderType + WriteInto + Clone> Plugin for UniformComponentP
                 .insert_resource(ComponentUniforms::<C>::default())
                 .add_systems(
                     Render,
-                    prepare_uniform_components::<C>.in_set(RenderSet::Prepare),
+                    prepare_uniform_components::<C>.in_set(RenderSet::PrepareResources),
                 );
         }
     }

--- a/crates/bevy_render/src/globals.rs
+++ b/crates/bevy_render/src/globals.rs
@@ -27,7 +27,10 @@ impl Plugin for GlobalsPlugin {
                 .init_resource::<GlobalsBuffer>()
                 .init_resource::<Time>()
                 .add_systems(ExtractSchedule, (extract_frame_count, extract_time))
-                .add_systems(Render, prepare_globals_buffer.in_set(RenderSet::Prepare));
+                .add_systems(
+                    Render,
+                    prepare_globals_buffer.in_set(RenderSet::PrepareResources),
+                );
         }
     }
 }

--- a/crates/bevy_render/src/gpu_component_array_buffer.rs
+++ b/crates/bevy_render/src/gpu_component_array_buffer.rs
@@ -20,7 +20,7 @@ impl<C: Component + GpuArrayBufferable> Plugin for GpuComponentArrayBufferPlugin
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app.add_systems(
                 Render,
-                prepare_gpu_component_array_buffers::<C>.in_set(RenderSet::Prepare),
+                prepare_gpu_component_array_buffers::<C>.in_set(RenderSet::PrepareResources),
             );
         }
     }

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -132,7 +132,7 @@ impl Render {
     pub fn base_schedule() -> Schedule {
         use RenderSet::*;
 
-        let mut schedule = Schedule::new();
+        let mut schedule = Schedule::new(Self);
 
         // Create "stage-like" structure using buffer flushes + ordering
         schedule.add_systems((
@@ -295,12 +295,12 @@ impl Plugin for RenderPlugin {
             let mut render_app = App::empty();
             render_app.main_schedule_label = Box::new(Render);
 
-            let mut extract_schedule = Schedule::new();
+            let mut extract_schedule = Schedule::new(ExtractSchedule);
             extract_schedule.set_apply_final_deferred(false);
 
             render_app
-                .add_schedule(ExtractSchedule, extract_schedule)
-                .add_schedule(Render, Render::base_schedule())
+                .add_schedule(extract_schedule)
+                .add_schedule(Render::base_schedule())
                 .init_resource::<render_graph::RenderGraph>()
                 .insert_resource(app.world.resource::<AssetServer>().clone())
                 .add_systems(ExtractSchedule, PipelineCache::extract_shaders)

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -50,7 +50,8 @@ use wgpu::Instance;
 
 use crate::{
     camera::CameraPlugin,
-    mesh::{morph::MorphPlugin, MeshPlugin},
+    mesh::{morph::MorphPlugin, Mesh, MeshPlugin},
+    render_asset::prepare_assets,
     render_resource::{PipelineCache, Shader, ShaderLoader},
     renderer::{render_system, RenderInstance},
     settings::WgpuSettings,
@@ -83,21 +84,31 @@ pub enum RenderSet {
     /// The copy of [`apply_deferred`] that runs at the beginning of this schedule.
     /// This is used for applying the commands from the [`ExtractSchedule`]
     ExtractCommands,
-    /// Prepare render resources from the extracted data for the GPU.
-    Prepare,
-    /// The copy of [`apply_deferred`] that runs immediately after [`Prepare`](RenderSet::Prepare).
-    PrepareFlush,
-    /// Create [`BindGroups`](render_resource::BindGroup) that depend on
-    /// [`Prepare`](RenderSet::Prepare) data and queue up draw calls to run during the
-    /// [`Render`](RenderSet::Render) step.
+    /// Prepare assets that have been created/modified/removed this frame.
+    PrepareAssets,
+    /// Create any additional views such as those used for shadow mapping.
+    ManageViews,
+    /// The copy of [`apply_deferred`] that runs immediately after [`ManageViews`](RenderSet::ManageViews).
+    ManageViewsFlush,
+    /// Queue drawable entities as phase items in [`RenderPhase`](crate::render_phase::RenderPhase)s
+    /// ready for sorting
     Queue,
-    /// The copy of [`apply_deferred`] that runs immediately after [`Queue`](RenderSet::Queue).
-    QueueFlush,
+    /// A sub-set within Queue where mesh entity queue systems are executed. Ensures `prepare_assets::<Mesh>` is completed.
+    QueueMeshes,
     // TODO: This could probably be moved in favor of a system ordering abstraction in Render or Queue
     /// Sort the [`RenderPhases`](render_phase::RenderPhase) here.
     PhaseSort,
-    /// The copy of [`apply_deferred`] that runs immediately after [`PhaseSort`](RenderSet::PhaseSort).
-    PhaseSortFlush,
+    /// Prepare render resources from extracted data for the GPU based on their sorted order.
+    /// Create [`BindGroups`](crate::render_resource::BindGroup) that depend on those data.
+    Prepare,
+    /// A sub-set within Prepare for initializing buffers, textures and uniforms for use in bind groups.
+    PrepareResources,
+    /// The copy of [`apply_deferred`] that runs between [`PrepareResources`](RenderSet::PrepareResources) and ['PrepareBindGroups'](RenderSet::PrepareBindGroups).
+    PrepareResourcesFlush,
+    /// A sub-set within Prepare for constructing bind groups, or other data that relies on render resources prepared in [`PrepareResources`](RenderSet::PrepareResources).
+    PrepareBindGroups,
+    /// The copy of [`apply_deferred`] that runs immediately after [`Prepare`](RenderSet::Prepare).
+    PrepareFlush,
     /// Actual rendering happens here.
     /// In most cases, only the render backend should insert resources here.
     Render,
@@ -125,28 +136,40 @@ impl Render {
 
         // Create "stage-like" structure using buffer flushes + ordering
         schedule.add_systems((
-            apply_deferred.in_set(PrepareFlush),
-            apply_deferred.in_set(QueueFlush),
-            apply_deferred.in_set(PhaseSortFlush),
+            apply_deferred.in_set(ManageViewsFlush),
+            apply_deferred.in_set(PrepareResourcesFlush),
             apply_deferred.in_set(RenderFlush),
+            apply_deferred.in_set(PrepareFlush),
             apply_deferred.in_set(CleanupFlush),
         ));
 
         schedule.configure_sets(
             (
                 ExtractCommands,
+                ManageViews,
+                ManageViewsFlush,
+                Queue,
+                PhaseSort,
                 Prepare,
                 PrepareFlush,
-                Queue,
-                QueueFlush,
-                PhaseSort,
-                PhaseSortFlush,
                 Render,
                 RenderFlush,
                 Cleanup,
                 CleanupFlush,
             )
                 .chain(),
+        );
+
+        schedule.configure_sets((ExtractCommands, PrepareAssets, Prepare).chain());
+        schedule.configure_set(
+            QueueMeshes
+                .in_set(RenderSet::Queue)
+                .after(prepare_assets::<Mesh>),
+        );
+        schedule.configure_sets(
+            (PrepareResources, PrepareResourcesFlush, PrepareBindGroups)
+                .chain()
+                .in_set(Prepare),
         );
 
         schedule

--- a/crates/bevy_render/src/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mod.rs
@@ -6,7 +6,7 @@ pub mod shape;
 
 pub use mesh::*;
 
-use crate::render_asset::RenderAssetPlugin;
+use crate::{prelude::Image, render_asset::RenderAssetPlugin};
 use bevy_app::{App, Plugin};
 use bevy_asset::AddAsset;
 use bevy_ecs::entity::Entity;
@@ -20,6 +20,7 @@ impl Plugin for MeshPlugin {
             .add_asset::<skinning::SkinnedMeshInverseBindposes>()
             .register_type::<skinning::SkinnedMesh>()
             .register_type::<Vec<Entity>>()
-            .add_plugins(RenderAssetPlugin::<Mesh>::default());
+            // 'Mesh' must be prepared after 'Image' as meshes rely on the morph target image being ready
+            .add_plugins(RenderAssetPlugin::<Mesh, Image>::default());
     }
 }

--- a/crates/bevy_render/src/mesh/morph.rs
+++ b/crates/bevy_render/src/mesh/morph.rs
@@ -74,8 +74,11 @@ impl MorphTargetImage {
             return Err(MorphBuildError::TooManyTargets { target_count });
         }
         let component_count = (vertex_count * MorphAttributes::COMPONENT_COUNT) as u32;
-        let Some((Rect(width, height), padding)) = lowest_2d(component_count , max) else {
-            return Err(MorphBuildError::TooManyAttributes { vertex_count, component_count });
+        let Some((Rect(width, height), padding)) = lowest_2d(component_count, max) else {
+            return Err(MorphBuildError::TooManyAttributes {
+                vertex_count,
+                component_count,
+            });
         };
         let data = targets
             .flat_map(|mut attributes| {

--- a/crates/bevy_render/src/pipelined_rendering.rs
+++ b/crates/bevy_render/src/pipelined_rendering.rs
@@ -111,7 +111,9 @@ impl Plugin for PipelinedRenderingPlugin {
                         s.spawn(async { app_to_render_receiver.recv().await });
                     })
                     .pop();
-                let Some(Ok(mut render_app)) = sent_app else { break };
+                let Some(Ok(mut render_app)) = sent_app else {
+                    break;
+                };
 
                 {
                     #[cfg(feature = "trace")]

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -3,7 +3,32 @@ use bevy_math::{Affine3A, Mat3A, Mat4, Vec3, Vec3A, Vec4, Vec4Swizzles};
 use bevy_reflect::Reflect;
 use bevy_utils::HashMap;
 
-/// An axis-aligned bounding box.
+/// An axis-aligned bounding box, defined by:
+/// - a center,
+/// - the distances from the center to each faces along the axis,
+/// the faces are orthogonal to the axis.
+///
+/// It is typically used as a component on an entity to represent the local space
+/// occupied by this entity, with faces orthogonal to its local axis.
+///
+/// This component is notably used during "frustum culling", a process to determine
+/// if an entity should be rendered by a [`Camera`] if its bounding box intersects
+/// with the camera's [`Frustum`].
+///
+/// It will be added automatically by the systems in [`CalculateBounds`] to entities that:
+/// - could be subject to frustum culling, for example with a [`Handle<Mesh>`]
+/// or `Sprite` component,
+/// - don't have the [`NoFrustumCulling`] component.
+///
+/// It won't be updated automatically if the space occupied by the entity changes,
+/// for example if the vertex positions of a [`Mesh`] inside a `Handle<Mesh>` are
+/// updated.
+///
+/// [`Camera`]: crate::camera::Camera
+/// [`NoFrustumCulling`]: crate::view::visibility::NoFrustumCulling
+/// [`CalculateBounds`]: crate::view::visibility::VisibilitySystems::CalculateBounds
+/// [`Mesh`]: crate::mesh::Mesh
+/// [`Handle<Mesh>`]: crate::mesh::Mesh
 #[derive(Component, Clone, Copy, Debug, Default, Reflect)]
 #[reflect(Component)]
 pub struct Aabb {
@@ -76,11 +101,28 @@ impl Sphere {
     }
 }
 
-/// A bisecting plane that partitions 3D space into two regions.
+/// A region of 3D space, specifically an open set whose border is a bisecting 2D plane.
+/// This bisecting plane partitions 3D space into two infinite regions,
+/// the half-space is one of those regions and excludes the bisecting plane.
 ///
-/// Each instance of this type is characterized by the bisecting plane's unit normal and distance from the origin along the normal.
-/// Any point `p` is considered to be within the `HalfSpace` when the distance is positive,
-/// meaning: if the equation `n.p + d > 0` is satisfied.
+/// Each instance of this type is characterized by:
+/// - the bisecting plane's unit normal, normalized and pointing "inside" the half-space,
+/// - the signed distance along the normal from the bisecting plane to the origin of 3D space.
+///
+/// The distance can also be seen as:
+/// - the distance along the inverse of the normal from the origin of 3D space to the bisecting plane,
+/// - the opposite of the distance along the normal from the origin of 3D space to the bisecting plane.
+///
+/// Any point `p` is considered to be within the `HalfSpace` when the length of the projection
+/// of p on the normal is greater or equal than the opposite of the distance,
+/// meaning: if the equation `normal.dot(p) + distance > 0.` is satisfied.
+///
+/// For example, the half-space containing all the points with a z-coordinate lesser
+/// or equal than `8.0` would be defined by: `HalfSpace::new(Vec3::NEG_Z.extend(-8.0))`.
+/// It includes all the points from the bisecting plane towards `NEG_Z`, and the distance
+/// from the plane to the origin is `-8.0` along `NEG_Z`.
+///
+/// It is used to define a [`Frustum`], but is also a useful mathematical primitive for rendering tasks such as  light computation.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct HalfSpace {
     normal_d: Vec4,
@@ -88,8 +130,8 @@ pub struct HalfSpace {
 
 impl HalfSpace {
     /// Constructs a `HalfSpace` from a 4D vector whose first 3 components
-    /// represent the bisecting plane's unit normal, and the last component signifies
-    /// the distance from the origin to the plane along the normal.
+    /// represent the bisecting plane's unit normal, and the last component is
+    /// the signed distance along the normal from the plane to the origin.
     /// The constructor ensures the normal vector is normalized and the distance is appropriately scaled.
     #[inline]
     pub fn new(normal_d: Vec4) -> Self {
@@ -104,23 +146,46 @@ impl HalfSpace {
         Vec3A::from(self.normal_d)
     }
 
-    /// Returns the distance from the origin to the bisecting plane along the plane's unit normal vector.
-    /// This distance helps determine the position of a point `p` on the bisecting plane, as per the equation `n.p + d = 0`.
+    /// Returns the signed distance from the bisecting plane to the origin along
+    /// the plane's unit normal vector.
     #[inline]
     pub fn d(&self) -> f32 {
         self.normal_d.w
     }
 
-    /// Returns the bisecting plane's unit normal vector and the distance from the origin to the plane.
+    /// Returns the bisecting plane's unit normal vector and the signed distance
+    /// from the plane to the origin.
     #[inline]
     pub fn normal_d(&self) -> Vec4 {
         self.normal_d
     }
 }
 
-/// A frustum made up of the 6 defining half spaces.
-/// Half spaces are ordered left, right, top, bottom, near, far.
-/// The normal vectors of the half spaces point towards the interior of the frustum.
+/// A region of 3D space defined by the intersection of 6 [`HalfSpace`]s.
+///
+/// Frustums are typically an apex-truncated square pyramid (a pyramid without the top) or a cuboid.
+///
+/// Half spaces are ordered left, right, top, bottom, near, far. The normal vectors
+/// of the half-spaces point towards the interior of the frustum.
+///
+/// A frustum component is used on an entity with a [`Camera`] component to
+/// determine which entities will be considered for rendering by this camera.
+/// All entities with an [`Aabb`] component that are not contained by (or crossing
+/// the boundary of) the frustum will not be rendered, and not be used in rendering computations.
+///
+/// This process is called frustum culling, and entities can opt out of it using
+/// the [`NoFrustumCulling`] component.
+///
+/// The frustum component is typically added from a bundle, either the `Camera2dBundle`
+/// or the `Camera3dBundle`.
+/// It is usually updated automatically by [`update_frusta`] from the
+/// [`CameraProjection`] component and [`GlobalTransform`] of the camera entity.
+///
+/// [`Camera`]: crate::camera::Camera
+/// [`NoFrustumCulling`]: crate::view::visibility::NoFrustumCulling
+/// [`update_frusta`]: crate::view::visibility::update_frusta
+/// [`CameraProjection`]: crate::camera::CameraProjection
+/// [`GlobalTransform`]: bevy_transform::components::GlobalTransform
 #[derive(Component, Clone, Copy, Debug, Default, Reflect)]
 #[reflect(Component)]
 pub struct Frustum {

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -4,6 +4,7 @@ use bevy_asset::{Asset, AssetEvent, Assets, Handle};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     prelude::*,
+    schedule::SystemConfigs,
     system::{StaticSystemParam, SystemParam, SystemParamItem},
 };
 use bevy_utils::{HashMap, HashSet};
@@ -20,7 +21,7 @@ pub enum PrepareAssetError<E: Send + Sync + 'static> {
 /// Therefore it is converted into a [`RenderAsset::ExtractedAsset`], which may be the same type
 /// as the render asset itself.
 ///
-/// After that in the [`RenderSet::Prepare`](crate::RenderSet::Prepare) step the extracted asset
+/// After that in the [`RenderSet::PrepareAssets`](crate::RenderSet::PrepareAssets) step the extracted asset
 /// is transformed into its GPU-representation of type [`RenderAsset::PreparedAsset`].
 pub trait RenderAsset: Asset {
     /// The representation of the asset in the "render world".
@@ -40,65 +41,62 @@ pub trait RenderAsset: Asset {
     ) -> Result<Self::PreparedAsset, PrepareAssetError<Self::ExtractedAsset>>;
 }
 
-#[derive(Clone, Hash, Debug, Default, PartialEq, Eq, SystemSet)]
-pub enum PrepareAssetSet {
-    PreAssetPrepare,
-    #[default]
-    AssetPrepare,
-    PostAssetPrepare,
-}
-
 /// This plugin extracts the changed assets from the "app world" into the "render world"
 /// and prepares them for the GPU. They can then be accessed from the [`RenderAssets`] resource.
 ///
 /// Therefore it sets up the [`ExtractSchedule`](crate::ExtractSchedule) and
-/// [`RenderSet::Prepare`](crate::RenderSet::Prepare) steps for the specified [`RenderAsset`].
-pub struct RenderAssetPlugin<A: RenderAsset> {
-    prepare_asset_set: PrepareAssetSet,
-    phantom: PhantomData<fn() -> A>,
+/// [`RenderSet::PrepareAssets`](crate::RenderSet::PrepareAssets) steps for the specified [`RenderAsset`].
+///
+/// The `AFTER` generic parameter can be used to specify that `A::prepare_asset` should not be run until
+/// `prepare_assets::<AFTER>` has completed. This allows the `prepare_asset` function to depend on another
+/// prepared [`RenderAsset`], for example `Mesh::prepare_asset` relies on `RenderAssets::<Image>` for morph
+/// targets, so the plugin is created as `RenderAssetPlugin::<Mesh, Image>::default()`.
+pub struct RenderAssetPlugin<A: RenderAsset, AFTER: RenderAssetDependency + 'static = ()> {
+    phantom: PhantomData<fn() -> (A, AFTER)>,
 }
 
-impl<A: RenderAsset> RenderAssetPlugin<A> {
-    pub fn with_prepare_asset_set(prepare_asset_set: PrepareAssetSet) -> Self {
-        Self {
-            prepare_asset_set,
-            phantom: PhantomData,
-        }
-    }
-}
-
-impl<A: RenderAsset> Default for RenderAssetPlugin<A> {
+impl<A: RenderAsset, AFTER: RenderAssetDependency + 'static> Default
+    for RenderAssetPlugin<A, AFTER>
+{
     fn default() -> Self {
         Self {
-            prepare_asset_set: Default::default(),
-            phantom: PhantomData,
+            phantom: Default::default(),
         }
     }
 }
 
-impl<A: RenderAsset> Plugin for RenderAssetPlugin<A> {
+impl<A: RenderAsset, AFTER: RenderAssetDependency + 'static> Plugin
+    for RenderAssetPlugin<A, AFTER>
+{
     fn build(&self, app: &mut App) {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
                 .init_resource::<ExtractedAssets<A>>()
                 .init_resource::<RenderAssets<A>>()
                 .init_resource::<PrepareNextFrameAssets<A>>()
-                .add_systems(ExtractSchedule, extract_render_asset::<A>)
-                .configure_sets(
-                    Render,
-                    (
-                        PrepareAssetSet::PreAssetPrepare,
-                        PrepareAssetSet::AssetPrepare,
-                        PrepareAssetSet::PostAssetPrepare,
-                    )
-                        .chain()
-                        .in_set(RenderSet::Prepare),
-                )
-                .add_systems(
-                    Render,
-                    prepare_assets::<A>.in_set(self.prepare_asset_set.clone()),
-                );
+                .add_systems(ExtractSchedule, extract_render_asset::<A>);
+            AFTER::register_system(
+                render_app,
+                prepare_assets::<A>.in_set(RenderSet::PrepareAssets),
+            );
         }
+    }
+}
+
+// helper to allow specifying dependencies between render assets
+pub trait RenderAssetDependency {
+    fn register_system(render_app: &mut App, system: SystemConfigs);
+}
+
+impl RenderAssetDependency for () {
+    fn register_system(render_app: &mut App, system: SystemConfigs) {
+        render_app.add_systems(Render, system);
+    }
+}
+
+impl<A: RenderAsset> RenderAssetDependency for A {
+    fn register_system(render_app: &mut App, system: SystemConfigs) {
+        render_app.add_systems(Render, system.after(prepare_assets::<A>));
     }
 }
 

--- a/crates/bevy_render/src/render_graph/graph.rs
+++ b/crates/bevy_render/src/render_graph/graph.rs
@@ -125,7 +125,9 @@ impl RenderGraph {
     /// It simply won't create a new edge.
     pub fn add_node_edges(&mut self, edges: &[&'static str]) {
         for window in edges.windows(2) {
-            let [a, b] = window else { break; };
+            let [a, b] = window else {
+                break;
+            };
             if let Err(err) = self.try_add_node_edge(*a, *b) {
                 match err {
                     // Already existing edges are very easy to produce with this api

--- a/crates/bevy_render/src/render_graph/node.rs
+++ b/crates/bevy_render/src/render_graph/node.rs
@@ -398,10 +398,9 @@ where
         render_context: &mut RenderContext,
         world: &World,
     ) -> Result<(), NodeRunError> {
-        let Ok(view) = self
-            .view_query
-            .get_manual(world, graph.view_entity())
-        else { return Ok(()); };
+        let Ok(view) = self.view_query.get_manual(world, graph.view_entity()) else {
+            return Ok(());
+        };
 
         ViewNode::run(&self.node, graph, render_context, view, world)?;
         Ok(())

--- a/crates/bevy_render/src/render_phase/mod.rs
+++ b/crates/bevy_render/src/render_phase/mod.rs
@@ -73,6 +73,12 @@ impl<I: PhaseItem> RenderPhase<I> {
         I::sort(&mut self.items);
     }
 
+    /// An [`Iterator`] through the associated [`Entity`] for each [`PhaseItem`] in order.
+    #[inline]
+    pub fn iter_entities(&'_ self) -> impl Iterator<Item = Entity> + '_ {
+        self.items.iter().map(|item| item.entity())
+    }
+
     /// Renders all of its [`PhaseItem`]s using their corresponding draw functions.
     pub fn render<'w>(
         &self,
@@ -84,9 +90,17 @@ impl<I: PhaseItem> RenderPhase<I> {
         let mut draw_functions = draw_functions.write();
         draw_functions.prepare(world);
 
-        for item in &self.items {
-            let draw_function = draw_functions.get_mut(item.draw_function()).unwrap();
-            draw_function.draw(world, render_pass, view, item);
+        let mut index = 0;
+        while index < self.items.len() {
+            let item = &self.items[index];
+            let batch_size = item.batch_size();
+            if batch_size > 0 {
+                let draw_function = draw_functions.get_mut(item.draw_function()).unwrap();
+                draw_function.draw(world, render_pass, view, item);
+                index += batch_size;
+            } else {
+                index += 1;
+            }
         }
     }
 
@@ -102,41 +116,22 @@ impl<I: PhaseItem> RenderPhase<I> {
         let mut draw_functions = draw_functions.write();
         draw_functions.prepare(world);
 
-        for item in self
+        let items = self
             .items
             .get(range)
-            .expect("`Range` provided to `render_range()` is out of bounds")
-            .iter()
-        {
-            let draw_function = draw_functions.get_mut(item.draw_function()).unwrap();
-            draw_function.draw(world, render_pass, view, item);
-        }
-    }
-}
+            .expect("`Range` provided to `render_range()` is out of bounds");
 
-impl<I: BatchedPhaseItem> RenderPhase<I> {
-    /// Batches the compatible [`BatchedPhaseItem`]s of this render phase
-    pub fn batch(&mut self) {
-        // TODO: this could be done in-place
-        let mut items = std::mem::take(&mut self.items).into_iter();
-
-        self.items.reserve(items.len());
-
-        // Start the first batch from the first item
-        if let Some(mut current_batch) = items.next() {
-            // Batch following items until we find an incompatible item
-            for next_item in items {
-                if matches!(
-                    current_batch.add_to_batch(&next_item),
-                    BatchResult::IncompatibleItems
-                ) {
-                    // Store the completed batch, and start a new one from the incompatible item
-                    self.items.push(current_batch);
-                    current_batch = next_item;
-                }
+        let mut index = 0;
+        while index < items.len() {
+            let item = &items[index];
+            let batch_size = item.batch_size();
+            if batch_size > 0 {
+                let draw_function = draw_functions.get_mut(item.draw_function()).unwrap();
+                draw_function.draw(world, render_pass, view, item);
+                index += batch_size;
+            } else {
+                index += 1;
             }
-            // Store the last batch
-            self.items.push(current_batch);
         }
     }
 }
@@ -171,7 +166,7 @@ pub trait PhaseItem: Sized + Send + Sync + 'static {
     fn draw_function(&self) -> DrawFunctionId;
 
     /// Sorts a slice of phase items into render order. Generally if the same type
-    /// implements [`BatchedPhaseItem`], this should use a stable sort like [`slice::sort_by_key`].
+    /// is batched this should use a stable sort like [`slice::sort_by_key`].
     /// In almost all other cases, this should not be altered from the default,
     /// which uses a unstable sort, as this provides the best balance of CPU and GPU
     /// performance.
@@ -185,6 +180,13 @@ pub trait PhaseItem: Sized + Send + Sync + 'static {
     #[inline]
     fn sort(items: &mut [Self]) {
         items.sort_unstable_by_key(|item| item.sort_key());
+    }
+
+    /// The number of items to skip after rendering this [`PhaseItem`].
+    ///
+    /// Items with a `batch_size` of 0 will not be rendered.
+    fn batch_size(&self) -> usize {
+        1
     }
 }
 
@@ -225,182 +227,9 @@ impl<P: CachedRenderPipelinePhaseItem> RenderCommand<P> for SetItemPipeline {
     }
 }
 
-/// A [`PhaseItem`] that can be batched dynamically.
-///
-/// Batching is an optimization that regroups multiple items in the same vertex buffer
-/// to render them in a single draw call.
-///
-/// If this is implemented on a type, the implementation of [`PhaseItem::sort`] should
-/// be changed to implement a stable sort, or incorrect/suboptimal batching may result.
-pub trait BatchedPhaseItem: PhaseItem {
-    /// Range in the vertex buffer of this item.
-    fn batch_range(&self) -> &Option<Range<u32>>;
-
-    /// Range in the vertex buffer of this item.
-    fn batch_range_mut(&mut self) -> &mut Option<Range<u32>>;
-
-    /// Batches another item within this item if they are compatible.
-    /// Items can be batched together if they have the same entity, and consecutive ranges.
-    /// If batching is successful, the `other` item should be discarded from the render pass.
-    #[inline]
-    fn add_to_batch(&mut self, other: &Self) -> BatchResult {
-        let self_entity = self.entity();
-        if let (Some(self_batch_range), Some(other_batch_range)) = (
-            self.batch_range_mut().as_mut(),
-            other.batch_range().as_ref(),
-        ) {
-            // If the items are compatible, join their range into `self`
-            if self_entity == other.entity() {
-                if self_batch_range.end == other_batch_range.start {
-                    self_batch_range.end = other_batch_range.end;
-                    return BatchResult::Success;
-                } else if self_batch_range.start == other_batch_range.end {
-                    self_batch_range.start = other_batch_range.start;
-                    return BatchResult::Success;
-                }
-            }
-        }
-        BatchResult::IncompatibleItems
-    }
-}
-
-/// The result of a batching operation.
-pub enum BatchResult {
-    /// The `other` item was batched into `self`
-    Success,
-    /// `self` and `other` cannot be batched together
-    IncompatibleItems,
-}
-
 /// This system sorts the [`PhaseItem`]s of all [`RenderPhase`]s of this type.
 pub fn sort_phase_system<I: PhaseItem>(mut render_phases: Query<&mut RenderPhase<I>>) {
     for mut phase in &mut render_phases {
         phase.sort();
-    }
-}
-
-/// This system batches the [`PhaseItem`]s of all [`RenderPhase`]s of this type.
-pub fn batch_phase_system<I: BatchedPhaseItem>(mut render_phases: Query<&mut RenderPhase<I>>) {
-    for mut phase in &mut render_phases {
-        phase.batch();
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use bevy_ecs::entity::Entity;
-    use std::ops::Range;
-
-    #[test]
-    fn batching() {
-        #[derive(Debug, PartialEq)]
-        struct TestPhaseItem {
-            entity: Entity,
-            batch_range: Option<Range<u32>>,
-        }
-        impl PhaseItem for TestPhaseItem {
-            type SortKey = ();
-
-            fn entity(&self) -> Entity {
-                self.entity
-            }
-
-            fn sort_key(&self) -> Self::SortKey {}
-
-            fn draw_function(&self) -> DrawFunctionId {
-                unimplemented!();
-            }
-        }
-        impl BatchedPhaseItem for TestPhaseItem {
-            fn batch_range(&self) -> &Option<Range<u32>> {
-                &self.batch_range
-            }
-
-            fn batch_range_mut(&mut self) -> &mut Option<Range<u32>> {
-                &mut self.batch_range
-            }
-        }
-        let mut render_phase = RenderPhase::<TestPhaseItem>::default();
-        let items = [
-            TestPhaseItem {
-                entity: Entity::from_raw(0),
-                batch_range: Some(0..5),
-            },
-            // This item should be batched
-            TestPhaseItem {
-                entity: Entity::from_raw(0),
-                batch_range: Some(5..10),
-            },
-            TestPhaseItem {
-                entity: Entity::from_raw(1),
-                batch_range: Some(0..5),
-            },
-            TestPhaseItem {
-                entity: Entity::from_raw(0),
-                batch_range: Some(10..15),
-            },
-            TestPhaseItem {
-                entity: Entity::from_raw(1),
-                batch_range: Some(5..10),
-            },
-            TestPhaseItem {
-                entity: Entity::from_raw(1),
-                batch_range: None,
-            },
-            TestPhaseItem {
-                entity: Entity::from_raw(1),
-                batch_range: Some(10..15),
-            },
-            TestPhaseItem {
-                entity: Entity::from_raw(1),
-                batch_range: Some(20..25),
-            },
-            // This item should be batched
-            TestPhaseItem {
-                entity: Entity::from_raw(1),
-                batch_range: Some(25..30),
-            },
-            // This item should be batched
-            TestPhaseItem {
-                entity: Entity::from_raw(1),
-                batch_range: Some(30..35),
-            },
-        ];
-        for item in items {
-            render_phase.add(item);
-        }
-        render_phase.batch();
-        let items_batched = [
-            TestPhaseItem {
-                entity: Entity::from_raw(0),
-                batch_range: Some(0..10),
-            },
-            TestPhaseItem {
-                entity: Entity::from_raw(1),
-                batch_range: Some(0..5),
-            },
-            TestPhaseItem {
-                entity: Entity::from_raw(0),
-                batch_range: Some(10..15),
-            },
-            TestPhaseItem {
-                entity: Entity::from_raw(1),
-                batch_range: Some(5..10),
-            },
-            TestPhaseItem {
-                entity: Entity::from_raw(1),
-                batch_range: None,
-            },
-            TestPhaseItem {
-                entity: Entity::from_raw(1),
-                batch_range: Some(10..15),
-            },
-            TestPhaseItem {
-                entity: Entity::from_raw(1),
-                batch_range: Some(20..35),
-            },
-        ];
-        assert_eq!(&*render_phase.items, items_batched);
     }
 }

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -31,9 +31,7 @@ pub use image_texture_loader::*;
 pub use texture_cache::*;
 
 use crate::{
-    render_asset::{PrepareAssetSet, RenderAssetPlugin},
-    renderer::RenderDevice,
-    Render, RenderApp, RenderSet,
+    render_asset::RenderAssetPlugin, renderer::RenderDevice, Render, RenderApp, RenderSet,
 };
 use bevy_app::{App, Plugin};
 use bevy_asset::{AddAsset, Assets};
@@ -80,12 +78,10 @@ impl Plugin for ImagePlugin {
             app.init_asset_loader::<HdrTextureLoader>();
         }
 
-        app.add_plugins(RenderAssetPlugin::<Image>::with_prepare_asset_set(
-            PrepareAssetSet::PreAssetPrepare,
-        ))
-        .register_type::<Image>()
-        .add_asset::<Image>()
-        .register_asset_reflect::<Image>();
+        app.add_plugins(RenderAssetPlugin::<Image>::default())
+            .register_type::<Image>()
+            .add_asset::<Image>()
+            .register_asset_reflect::<Image>();
         app.world
             .resource_mut::<Assets<Image>>()
             .set_untracked(DEFAULT_IMAGE_HANDLE, Image::default());

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -53,19 +53,16 @@ impl Plugin for ViewPlugin {
             .add_plugins((ExtractResourcePlugin::<Msaa>::default(), VisibilityPlugin));
 
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .init_resource::<ViewUniforms>()
-                .configure_set(Render, ViewSet::PrepareUniforms.in_set(RenderSet::Prepare))
-                .add_systems(
-                    Render,
-                    (
-                        prepare_view_uniforms.in_set(ViewSet::PrepareUniforms),
-                        prepare_view_targets
-                            .after(WindowSystem::Prepare)
-                            .in_set(RenderSet::Prepare)
-                            .after(crate::render_asset::prepare_assets::<Image>),
-                    ),
-                );
+            render_app.init_resource::<ViewUniforms>().add_systems(
+                Render,
+                (
+                    prepare_view_targets
+                        .in_set(RenderSet::ManageViews)
+                        .after(prepare_windows)
+                        .after(crate::render_asset::prepare_assets::<Image>),
+                    prepare_view_uniforms.in_set(RenderSet::PrepareResources),
+                ),
+            );
         }
     }
 }
@@ -516,11 +513,4 @@ fn prepare_view_targets(
             }
         }
     }
-}
-
-/// System sets for the [`view`](crate::view) module.
-#[derive(SystemSet, PartialEq, Eq, Hash, Debug, Clone)]
-pub enum ViewSet {
-    /// Prepares view uniforms
-    PrepareUniforms,
 }

--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -27,11 +27,6 @@ pub struct NonSendMarker;
 
 pub struct WindowRenderPlugin;
 
-#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
-pub enum WindowSystem {
-    Prepare,
-}
-
 impl Plugin for WindowRenderPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(ScreenshotPlugin);
@@ -42,8 +37,7 @@ impl Plugin for WindowRenderPlugin {
                 .init_resource::<WindowSurfaces>()
                 .init_non_send_resource::<NonSendMarker>()
                 .add_systems(ExtractSchedule, extract_windows)
-                .configure_set(Render, WindowSystem::Prepare.in_set(RenderSet::Prepare))
-                .add_systems(Render, prepare_windows.in_set(WindowSystem::Prepare));
+                .add_systems(Render, prepare_windows.in_set(RenderSet::ManageViews));
         }
     }
 

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -3,7 +3,7 @@ use std::any::TypeId;
 use crate::{DynamicSceneBuilder, Scene, SceneSpawnError};
 use anyhow::Result;
 use bevy_ecs::{
-    entity::{Entity, EntityMap},
+    entity::Entity,
     reflect::{AppTypeRegistry, ReflectComponent, ReflectMapEntities},
     world::World,
 };
@@ -67,7 +67,7 @@ impl DynamicScene {
     pub fn write_to_world_with(
         &self,
         world: &mut World,
-        entity_map: &mut EntityMap,
+        entity_map: &mut HashMap<Entity, Entity>,
         type_registry: &AppTypeRegistry,
     ) -> Result<(), SceneSpawnError> {
         let type_registry = type_registry.read();
@@ -155,7 +155,7 @@ impl DynamicScene {
     pub fn write_to_world(
         &self,
         world: &mut World,
-        entity_map: &mut EntityMap,
+        entity_map: &mut HashMap<Entity, Entity>,
     ) -> Result<(), SceneSpawnError> {
         let registry = world.resource::<AppTypeRegistry>().clone();
         self.write_to_world_with(world, entity_map, &registry)
@@ -183,8 +183,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use bevy_ecs::{entity::EntityMap, reflect::AppTypeRegistry, system::Command, world::World};
+    use bevy_ecs::{reflect::AppTypeRegistry, system::Command, world::World};
     use bevy_hierarchy::{AddChild, Parent};
+    use bevy_utils::HashMap;
 
     use crate::dynamic_scene_builder::DynamicSceneBuilder;
 
@@ -213,11 +214,11 @@ mod tests {
         scene_builder.extract_entity(original_parent_entity);
         scene_builder.extract_entity(original_child_entity);
         let scene = scene_builder.build();
-        let mut entity_map = EntityMap::default();
+        let mut entity_map = HashMap::default();
         scene.write_to_world(&mut world, &mut entity_map).unwrap();
 
-        let from_scene_parent_entity = entity_map.get(original_parent_entity).unwrap();
-        let from_scene_child_entity = entity_map.get(original_child_entity).unwrap();
+        let &from_scene_parent_entity = entity_map.get(&original_parent_entity).unwrap();
+        let &from_scene_child_entity = entity_map.get(&original_child_entity).unwrap();
 
         // We then add the parent from the scene as a child of the original child
         // Hierarchy should look like:

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -1,9 +1,9 @@
 use bevy_ecs::{
-    entity::EntityMap,
     reflect::{AppTypeRegistry, ReflectComponent, ReflectMapEntities, ReflectResource},
     world::World,
 };
 use bevy_reflect::{TypePath, TypeUuid};
+use bevy_utils::HashMap;
 
 use crate::{DynamicScene, InstanceInfo, SceneSpawnError};
 
@@ -30,7 +30,7 @@ impl Scene {
         type_registry: &AppTypeRegistry,
     ) -> Result<Scene, SceneSpawnError> {
         let mut world = World::new();
-        let mut entity_map = EntityMap::default();
+        let mut entity_map = HashMap::default();
         dynamic_scene.write_to_world_with(&mut world, &mut entity_map, type_registry)?;
 
         Ok(Self { world })
@@ -56,7 +56,7 @@ impl Scene {
         type_registry: &AppTypeRegistry,
     ) -> Result<InstanceInfo, SceneSpawnError> {
         let mut instance_info = InstanceInfo {
-            entity_map: EntityMap::default(),
+            entity_map: HashMap::default(),
         };
 
         let type_registry = type_registry.read();

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -1,7 +1,7 @@
 use crate::{DynamicScene, Scene};
 use bevy_asset::{AssetEvent, Assets, Handle};
 use bevy_ecs::{
-    entity::{Entity, EntityMap},
+    entity::Entity,
     event::{Event, Events, ManualEventReader},
     reflect::AppTypeRegistry,
     system::{Command, Resource},
@@ -25,7 +25,7 @@ pub struct SceneInstanceReady {
 #[derive(Debug)]
 pub struct InstanceInfo {
     /// Mapping of entities from the scene world to the instance world.
-    pub entity_map: EntityMap,
+    pub entity_map: HashMap<Entity, Entity>,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -120,7 +120,7 @@ impl SceneSpawner {
 
     pub fn despawn_instance_sync(&mut self, world: &mut World, instance_id: &InstanceId) {
         if let Some(instance) = self.spawned_instances.remove(instance_id) {
-            for entity in instance.entity_map.values() {
+            for &entity in instance.entity_map.values() {
                 let _ = world.despawn(entity);
             }
         }
@@ -131,7 +131,7 @@ impl SceneSpawner {
         world: &mut World,
         scene_handle: &Handle<DynamicScene>,
     ) -> Result<(), SceneSpawnError> {
-        let mut entity_map = EntityMap::default();
+        let mut entity_map = HashMap::default();
         Self::spawn_dynamic_internal(world, scene_handle, &mut entity_map)?;
         let instance_id = InstanceId::new();
         self.spawned_instances
@@ -147,7 +147,7 @@ impl SceneSpawner {
     fn spawn_dynamic_internal(
         world: &mut World,
         scene_handle: &Handle<DynamicScene>,
-        entity_map: &mut EntityMap,
+        entity_map: &mut HashMap<Entity, Entity>,
     ) -> Result<(), SceneSpawnError> {
         world.resource_scope(|world, scenes: Mut<Assets<DynamicScene>>| {
             let scene =
@@ -237,7 +237,7 @@ impl SceneSpawner {
         let scenes_to_spawn = std::mem::take(&mut self.dynamic_scenes_to_spawn);
 
         for (scene_handle, instance_id) in scenes_to_spawn {
-            let mut entity_map = EntityMap::default();
+            let mut entity_map = HashMap::default();
 
             match Self::spawn_dynamic_internal(world, &scene_handle, &mut entity_map) {
                 Ok(_) => {
@@ -277,7 +277,7 @@ impl SceneSpawner {
 
         for (instance_id, parent) in scenes_with_parent {
             if let Some(instance) = self.spawned_instances.get(&instance_id) {
-                for entity in instance.entity_map.values() {
+                for &entity in instance.entity_map.values() {
                     // Add the `Parent` component to the scene root, and update the `Children` component of
                     // the scene parent
                     if !world
@@ -322,6 +322,7 @@ impl SceneSpawner {
             .map(|instance| instance.entity_map.values())
             .into_iter()
             .flatten()
+            .copied()
     }
 }
 

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -424,12 +424,13 @@ impl<'a, 'de> Visitor<'de> for SceneMapVisitor<'a> {
 mod tests {
     use crate::serde::{SceneDeserializer, SceneSerializer};
     use crate::{DynamicScene, DynamicSceneBuilder};
-    use bevy_ecs::entity::{Entity, EntityMap, EntityMapper, MapEntities};
+    use bevy_ecs::entity::{Entity, EntityMapper, MapEntities};
     use bevy_ecs::prelude::{Component, ReflectComponent, ReflectResource, Resource, World};
     use bevy_ecs::query::{With, Without};
     use bevy_ecs::reflect::{AppTypeRegistry, ReflectMapEntities};
     use bevy_ecs::world::FromWorld;
     use bevy_reflect::{Reflect, ReflectSerialize};
+    use bevy_utils::HashMap;
     use bincode::Options;
     use serde::de::DeserializeSeed;
     use serde::Serialize;
@@ -603,7 +604,7 @@ mod tests {
             "expected `entities` to contain 3 entities"
         );
 
-        let mut map = EntityMap::default();
+        let mut map = HashMap::default();
         let mut dst_world = create_world();
         scene.write_to_world(&mut dst_world, &mut map).unwrap();
 
@@ -642,7 +643,7 @@ mod tests {
 
         let deserialized_scene = scene_deserializer.deserialize(&mut deserializer).unwrap();
 
-        let mut map = EntityMap::default();
+        let mut map = HashMap::default();
         let mut dst_world = create_world();
         deserialized_scene
             .write_to_world(&mut dst_world, &mut map)

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -91,9 +91,12 @@ impl Plugin for SpritePlugin {
                 )
                 .add_systems(
                     Render,
-                    queue_sprites
-                        .in_set(RenderSet::Queue)
-                        .ambiguous_with(queue_material2d_meshes::<ColorMaterial>),
+                    (
+                        queue_sprites
+                            .in_set(RenderSet::Queue)
+                            .ambiguous_with(queue_material2d_meshes::<ColorMaterial>),
+                        prepare_sprites.in_set(RenderSet::PrepareBindGroups),
+                    ),
                 );
         };
     }

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -108,6 +108,13 @@ impl Plugin for SpritePlugin {
     }
 }
 
+/// System calculating and inserting an [`Aabb`] component to entities with either:
+/// - a `Mesh2dHandle` component,
+/// - a `Sprite` and `Handle<Image>` components,
+/// - a `TextureAtlasSprite` and `Handle<TextureAtlas>` components,
+/// and without a [`NoFrustumCulling`] component.
+///
+/// Used in system set [`VisibilitySystems::CalculateBounds`].
 pub fn calculate_bounds_2d(
     mut commands: Commands,
     meshes: Res<Assets<Mesh>>,

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -19,7 +19,7 @@ use bevy_render::{
     extract_component::ExtractComponentPlugin,
     mesh::{Mesh, MeshVertexBufferLayout},
     prelude::Image,
-    render_asset::{PrepareAssetSet, RenderAssets},
+    render_asset::{prepare_assets, RenderAssets},
     render_phase::{
         AddRenderCommand, DrawFunctions, PhaseItem, RenderCommand, RenderCommandResult,
         RenderPhase, SetItemPipeline, TrackedRenderPass,
@@ -165,9 +165,11 @@ where
                     Render,
                     (
                         prepare_materials_2d::<M>
-                            .in_set(RenderSet::Prepare)
-                            .after(PrepareAssetSet::PreAssetPrepare),
-                        queue_material2d_meshes::<M>.in_set(RenderSet::Queue),
+                            .in_set(RenderSet::PrepareAssets)
+                            .after(prepare_assets::<Image>),
+                        queue_material2d_meshes::<M>
+                            .in_set(RenderSet::QueueMeshes)
+                            .after(prepare_materials_2d::<M>),
                     ),
                 );
         }
@@ -415,7 +417,7 @@ pub fn queue_material2d_meshes<M: Material2d>(
                             // camera. As such we can just use mesh_z as the distance
                             sort_key: FloatOrd(mesh_z),
                             // This material is not batched
-                            batch_range: None,
+                            batch_size: 1,
                         });
                     }
                 }

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -106,8 +106,8 @@ impl Plugin for Mesh2dRenderPlugin {
                 .add_systems(
                     Render,
                     (
-                        queue_mesh2d_bind_group.in_set(RenderSet::Queue),
-                        queue_mesh2d_view_bind_groups.in_set(RenderSet::Queue),
+                        prepare_mesh2d_bind_group.in_set(RenderSet::PrepareBindGroups),
+                        prepare_mesh2d_view_bind_groups.in_set(RenderSet::PrepareBindGroups),
                     ),
                 );
         }
@@ -480,7 +480,7 @@ pub struct Mesh2dBindGroup {
     pub value: BindGroup,
 }
 
-pub fn queue_mesh2d_bind_group(
+pub fn prepare_mesh2d_bind_group(
     mut commands: Commands,
     mesh2d_pipeline: Res<Mesh2dPipeline>,
     render_device: Res<RenderDevice>,
@@ -505,7 +505,7 @@ pub struct Mesh2dViewBindGroup {
     pub value: BindGroup,
 }
 
-pub fn queue_mesh2d_view_bind_groups(
+pub fn prepare_mesh2d_view_bind_groups(
     mut commands: Commands,
     render_device: Res<RenderDevice>,
     mesh2d_pipeline: Res<Mesh2dPipeline>,

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use std::ops::Range;
 
 use crate::{
     texture_atlas::{TextureAtlas, TextureAtlasSprite},
@@ -11,16 +11,16 @@ use bevy_core_pipeline::{
 };
 use bevy_ecs::{
     prelude::*,
+    storage::SparseSet,
     system::{lifetimeless::*, SystemParamItem, SystemState},
 };
 use bevy_math::{Rect, Vec2};
-use bevy_reflect::Uuid;
 use bevy_render::{
     color::Color,
     render_asset::RenderAssets,
     render_phase::{
-        BatchedPhaseItem, DrawFunctions, PhaseItem, RenderCommand, RenderCommandResult,
-        RenderPhase, SetItemPipeline, TrackedRenderPass,
+        DrawFunctions, PhaseItem, RenderCommand, RenderCommandResult, RenderPhase, SetItemPipeline,
+        TrackedRenderPass,
     },
     render_resource::*,
     renderer::{RenderDevice, RenderQueue},
@@ -34,8 +34,7 @@ use bevy_render::{
     Extract,
 };
 use bevy_transform::components::GlobalTransform;
-use bevy_utils::FloatOrd;
-use bevy_utils::HashMap;
+use bevy_utils::{FloatOrd, HashMap, Uuid};
 use bytemuck::{Pod, Zeroable};
 use fixedbitset::FixedBitSet;
 
@@ -296,9 +295,7 @@ impl SpecializedRenderPipeline for SpritePipeline {
     }
 }
 
-#[derive(Component, Clone, Copy)]
 pub struct ExtractedSprite {
-    pub entity: Entity,
     pub transform: GlobalTransform,
     pub color: Color,
     /// Select an area of the texture
@@ -315,7 +312,7 @@ pub struct ExtractedSprite {
 
 #[derive(Resource, Default)]
 pub struct ExtractedSprites {
-    pub sprites: Vec<ExtractedSprite>,
+    pub sprites: SparseSet<Entity, ExtractedSprite>,
 }
 
 #[derive(Resource, Default)]
@@ -368,24 +365,25 @@ pub fn extract_sprites(
         )>,
     >,
 ) {
-    extracted_sprites.sprites.clear();
     for (entity, visibility, sprite, transform, handle) in sprite_query.iter() {
         if !visibility.is_visible() {
             continue;
         }
         // PERF: we don't check in this function that the `Image` asset is ready, since it should be in most cases and hashing the handle is expensive
-        extracted_sprites.sprites.push(ExtractedSprite {
+        extracted_sprites.sprites.insert(
             entity,
-            color: sprite.color,
-            transform: *transform,
-            rect: sprite.rect,
-            // Pass the custom size
-            custom_size: sprite.custom_size,
-            flip_x: sprite.flip_x,
-            flip_y: sprite.flip_y,
-            image_handle_id: handle.id(),
-            anchor: sprite.anchor.as_vec(),
-        });
+            ExtractedSprite {
+                color: sprite.color,
+                transform: *transform,
+                rect: sprite.rect,
+                // Pass the custom size
+                custom_size: sprite.custom_size,
+                flip_x: sprite.flip_x,
+                flip_y: sprite.flip_y,
+                image_handle_id: handle.id(),
+                anchor: sprite.anchor.as_vec(),
+            },
+        );
     }
     for (entity, visibility, atlas_sprite, transform, texture_atlas_handle) in atlas_query.iter() {
         if !visibility.is_visible() {
@@ -404,19 +402,21 @@ pub fn extract_sprites(
                         )
                     }),
             );
-            extracted_sprites.sprites.push(ExtractedSprite {
+            extracted_sprites.sprites.insert(
                 entity,
-                color: atlas_sprite.color,
-                transform: *transform,
-                // Select the area in the texture atlas
-                rect,
-                // Pass the custom size
-                custom_size: atlas_sprite.custom_size,
-                flip_x: atlas_sprite.flip_x,
-                flip_y: atlas_sprite.flip_y,
-                image_handle_id: texture_atlas.texture.id(),
-                anchor: atlas_sprite.anchor.as_vec(),
-            });
+                ExtractedSprite {
+                    color: atlas_sprite.color,
+                    transform: *transform,
+                    // Select the area in the texture atlas
+                    rect,
+                    // Pass the custom size
+                    custom_size: atlas_sprite.custom_size,
+                    flip_x: atlas_sprite.flip_x,
+                    flip_y: atlas_sprite.flip_y,
+                    image_handle_id: texture_atlas.texture.id(),
+                    anchor: atlas_sprite.anchor.as_vec(),
+                },
+            );
         }
     }
 }
@@ -469,8 +469,9 @@ const QUAD_UVS: [Vec2; 4] = [
     Vec2::new(0., 0.),
 ];
 
-#[derive(Component, Eq, PartialEq, Copy, Clone)]
+#[derive(Component)]
 pub struct SpriteBatch {
+    range: Range<u32>,
     image_handle_id: HandleId,
     colored: bool,
 }
@@ -482,20 +483,13 @@ pub struct ImageBindGroups {
 
 #[allow(clippy::too_many_arguments)]
 pub fn queue_sprites(
-    mut commands: Commands,
     mut view_entities: Local<FixedBitSet>,
     draw_functions: Res<DrawFunctions<Transparent2d>>,
-    render_device: Res<RenderDevice>,
-    render_queue: Res<RenderQueue>,
-    mut sprite_meta: ResMut<SpriteMeta>,
-    view_uniforms: Res<ViewUniforms>,
     sprite_pipeline: Res<SpritePipeline>,
     mut pipelines: ResMut<SpecializedRenderPipelines<SpritePipeline>>,
     pipeline_cache: Res<PipelineCache>,
-    mut image_bind_groups: ResMut<ImageBindGroups>,
-    gpu_images: Res<RenderAssets<Image>>,
     msaa: Res<Msaa>,
-    mut extracted_sprites: ResMut<ExtractedSprites>,
+    extracted_sprites: Res<ExtractedSprites>,
     mut views: Query<(
         &mut RenderPhase<Transparent2d>,
         &VisibleEntities,
@@ -503,6 +497,100 @@ pub fn queue_sprites(
         Option<&Tonemapping>,
         Option<&DebandDither>,
     )>,
+) {
+    let msaa_key = SpritePipelineKey::from_msaa_samples(msaa.samples());
+
+    let draw_sprite_function = draw_functions.read().id::<DrawSprite>();
+
+    for (mut transparent_phase, visible_entities, view, tonemapping, dither) in &mut views {
+        let mut view_key = SpritePipelineKey::from_hdr(view.hdr) | msaa_key;
+
+        if !view.hdr {
+            if let Some(tonemapping) = tonemapping {
+                view_key |= SpritePipelineKey::TONEMAP_IN_SHADER;
+                view_key |= match tonemapping {
+                    Tonemapping::None => SpritePipelineKey::TONEMAP_METHOD_NONE,
+                    Tonemapping::Reinhard => SpritePipelineKey::TONEMAP_METHOD_REINHARD,
+                    Tonemapping::ReinhardLuminance => {
+                        SpritePipelineKey::TONEMAP_METHOD_REINHARD_LUMINANCE
+                    }
+                    Tonemapping::AcesFitted => SpritePipelineKey::TONEMAP_METHOD_ACES_FITTED,
+                    Tonemapping::AgX => SpritePipelineKey::TONEMAP_METHOD_AGX,
+                    Tonemapping::SomewhatBoringDisplayTransform => {
+                        SpritePipelineKey::TONEMAP_METHOD_SOMEWHAT_BORING_DISPLAY_TRANSFORM
+                    }
+                    Tonemapping::TonyMcMapface => SpritePipelineKey::TONEMAP_METHOD_TONY_MC_MAPFACE,
+                    Tonemapping::BlenderFilmic => SpritePipelineKey::TONEMAP_METHOD_BLENDER_FILMIC,
+                };
+            }
+            if let Some(DebandDither::Enabled) = dither {
+                view_key |= SpritePipelineKey::DEBAND_DITHER;
+            }
+        }
+
+        let pipeline = pipelines.specialize(
+            &pipeline_cache,
+            &sprite_pipeline,
+            view_key | SpritePipelineKey::from_colored(false),
+        );
+        let colored_pipeline = pipelines.specialize(
+            &pipeline_cache,
+            &sprite_pipeline,
+            view_key | SpritePipelineKey::from_colored(true),
+        );
+
+        view_entities.clear();
+        view_entities.extend(visible_entities.entities.iter().map(|e| e.index() as usize));
+
+        transparent_phase
+            .items
+            .reserve(extracted_sprites.sprites.len());
+
+        for (entity, extracted_sprite) in extracted_sprites.sprites.iter() {
+            if !view_entities.contains(entity.index() as usize) {
+                continue;
+            }
+
+            // These items will be sorted by depth with other phase items
+            let sort_key = FloatOrd(extracted_sprite.transform.translation().z);
+
+            // Add the item to the render phase
+            if extracted_sprite.color != Color::WHITE {
+                transparent_phase.add(Transparent2d {
+                    draw_function: draw_sprite_function,
+                    pipeline: colored_pipeline,
+                    entity: *entity,
+                    sort_key,
+                    // batch_size will be calculated in prepare_sprites
+                    batch_size: 0,
+                });
+            } else {
+                transparent_phase.add(Transparent2d {
+                    draw_function: draw_sprite_function,
+                    pipeline,
+                    entity: *entity,
+                    sort_key,
+                    // batch_size will be calculated in prepare_sprites
+                    batch_size: 0,
+                });
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn prepare_sprites(
+    mut commands: Commands,
+    mut previous_len: Local<usize>,
+    render_device: Res<RenderDevice>,
+    render_queue: Res<RenderQueue>,
+    mut sprite_meta: ResMut<SpriteMeta>,
+    view_uniforms: Res<ViewUniforms>,
+    sprite_pipeline: Res<SpritePipeline>,
+    mut image_bind_groups: ResMut<ImageBindGroups>,
+    gpu_images: Res<RenderAssets<Image>>,
+    mut extracted_sprites: ResMut<ExtractedSprites>,
+    mut phases: Query<&mut RenderPhase<Transparent2d>>,
     events: Res<SpriteAssetEvents>,
 ) {
     // If an image has changed, the GpuImage has (probably) changed
@@ -515,9 +603,8 @@ pub fn queue_sprites(
         };
     }
 
-    let msaa_key = SpritePipelineKey::from_msaa_samples(msaa.samples());
-
     if let Some(view_binding) = view_uniforms.uniforms.binding() {
+        let mut batches: Vec<(Entity, SpriteBatch)> = Vec::with_capacity(*previous_len);
         let sprite_meta = &mut sprite_meta;
 
         // Clear the vertex buffers
@@ -533,210 +620,141 @@ pub fn queue_sprites(
             layout: &sprite_pipeline.view_layout,
         }));
 
-        let draw_sprite_function = draw_functions.read().id::<DrawSprite>();
-
         // Vertex buffer indices
         let mut index = 0;
         let mut colored_index = 0;
 
-        // FIXME: VisibleEntities is ignored
-
-        let extracted_sprites = &mut extracted_sprites.sprites;
-        // Sort sprites by z for correct transparency and then by handle to improve batching
-        // NOTE: This can be done independent of views by reasonably assuming that all 2D views look along the negative-z axis in world space
-        extracted_sprites.sort_unstable_by(|a, b| {
-            match a
-                .transform
-                .translation()
-                .z
-                .partial_cmp(&b.transform.translation().z)
-            {
-                Some(Ordering::Equal) | None => a.image_handle_id.cmp(&b.image_handle_id),
-                Some(other) => other,
-            }
-        });
         let image_bind_groups = &mut *image_bind_groups;
 
-        for (mut transparent_phase, visible_entities, view, tonemapping, dither) in &mut views {
-            let mut view_key = SpritePipelineKey::from_hdr(view.hdr) | msaa_key;
+        for mut transparent_phase in &mut phases {
+            let mut batch_item_index = 0;
+            let mut batch_image_size = Vec2::ZERO;
+            let mut batch_image_handle = HandleId::Id(Uuid::nil(), u64::MAX);
+            let mut batch_colored = false;
 
-            if !view.hdr {
-                if let Some(tonemapping) = tonemapping {
-                    view_key |= SpritePipelineKey::TONEMAP_IN_SHADER;
-                    view_key |= match tonemapping {
-                        Tonemapping::None => SpritePipelineKey::TONEMAP_METHOD_NONE,
-                        Tonemapping::Reinhard => SpritePipelineKey::TONEMAP_METHOD_REINHARD,
-                        Tonemapping::ReinhardLuminance => {
-                            SpritePipelineKey::TONEMAP_METHOD_REINHARD_LUMINANCE
-                        }
-                        Tonemapping::AcesFitted => SpritePipelineKey::TONEMAP_METHOD_ACES_FITTED,
-                        Tonemapping::AgX => SpritePipelineKey::TONEMAP_METHOD_AGX,
-                        Tonemapping::SomewhatBoringDisplayTransform => {
-                            SpritePipelineKey::TONEMAP_METHOD_SOMEWHAT_BORING_DISPLAY_TRANSFORM
-                        }
-                        Tonemapping::TonyMcMapface => {
-                            SpritePipelineKey::TONEMAP_METHOD_TONY_MC_MAPFACE
-                        }
-                        Tonemapping::BlenderFilmic => {
-                            SpritePipelineKey::TONEMAP_METHOD_BLENDER_FILMIC
-                        }
-                    };
-                }
-                if let Some(DebandDither::Enabled) = dither {
-                    view_key |= SpritePipelineKey::DEBAND_DITHER;
-                }
-            }
-
-            let pipeline = pipelines.specialize(
-                &pipeline_cache,
-                &sprite_pipeline,
-                view_key | SpritePipelineKey::from_colored(false),
-            );
-            let colored_pipeline = pipelines.specialize(
-                &pipeline_cache,
-                &sprite_pipeline,
-                view_key | SpritePipelineKey::from_colored(true),
-            );
-
-            view_entities.clear();
-            view_entities.extend(visible_entities.entities.iter().map(|e| e.index() as usize));
-            transparent_phase.items.reserve(extracted_sprites.len());
-
-            // Impossible starting values that will be replaced on the first iteration
-            let mut current_batch = SpriteBatch {
-                image_handle_id: HandleId::Id(Uuid::nil(), u64::MAX),
-                colored: false,
-            };
-            let mut current_batch_entity = Entity::PLACEHOLDER;
-            let mut current_image_size = Vec2::ZERO;
-            // Add a phase item for each sprite, and detect when successive items can be batched.
+            // Iterate through the phase items and detect when successive sprites that can be batched.
             // Spawn an entity with a `SpriteBatch` component for each possible batch.
             // Compatible items share the same entity.
-            // Batches are merged later (in `batch_phase_system()`), so that they can be interrupted
-            // by any other phase item (and they can interrupt other items from batching).
-            for extracted_sprite in extracted_sprites.iter() {
-                if !view_entities.contains(extracted_sprite.entity.index() as usize) {
-                    continue;
-                }
-                let new_batch = SpriteBatch {
-                    image_handle_id: extracted_sprite.image_handle_id,
-                    colored: extracted_sprite.color != Color::WHITE,
-                };
-                if new_batch != current_batch {
-                    // Set-up a new possible batch
-                    if let Some(gpu_image) =
-                        gpu_images.get(&Handle::weak(new_batch.image_handle_id))
-                    {
-                        current_batch = new_batch;
-                        current_image_size = Vec2::new(gpu_image.size.x, gpu_image.size.y);
-                        current_batch_entity = commands.spawn(current_batch).id();
+            for item_index in 0..transparent_phase.items.len() {
+                let item = &mut transparent_phase.items[item_index];
+                if let Some(extracted_sprite) = extracted_sprites.sprites.get(item.entity) {
+                    // Take a reference to an existing compatible batch if one exists
+                    let mut existing_batch = batches.last_mut().filter(|_| {
+                        batch_image_handle == extracted_sprite.image_handle_id
+                            && batch_colored == (extracted_sprite.color != Color::WHITE)
+                    });
 
-                        image_bind_groups
-                            .values
-                            .entry(Handle::weak(current_batch.image_handle_id))
-                            .or_insert_with(|| {
-                                render_device.create_bind_group(&BindGroupDescriptor {
-                                    entries: &[
-                                        BindGroupEntry {
-                                            binding: 0,
-                                            resource: BindingResource::TextureView(
-                                                &gpu_image.texture_view,
-                                            ),
-                                        },
-                                        BindGroupEntry {
-                                            binding: 1,
-                                            resource: BindingResource::Sampler(&gpu_image.sampler),
-                                        },
-                                    ],
-                                    label: Some("sprite_material_bind_group"),
-                                    layout: &sprite_pipeline.material_layout,
-                                })
+                    if existing_batch.is_none() {
+                        if let Some(gpu_image) =
+                            gpu_images.get(&Handle::weak(extracted_sprite.image_handle_id))
+                        {
+                            batch_item_index = item_index;
+                            batch_image_size = Vec2::new(gpu_image.size.x, gpu_image.size.y);
+                            batch_image_handle = extracted_sprite.image_handle_id;
+                            batch_colored = extracted_sprite.color != Color::WHITE;
+
+                            let new_batch = SpriteBatch {
+                                range: if batch_colored {
+                                    colored_index..colored_index
+                                } else {
+                                    index..index
+                                },
+                                colored: batch_colored,
+                                image_handle_id: batch_image_handle,
+                            };
+
+                            batches.push((item.entity, new_batch));
+
+                            image_bind_groups
+                                .values
+                                .entry(Handle::weak(batch_image_handle))
+                                .or_insert_with(|| {
+                                    render_device.create_bind_group(&BindGroupDescriptor {
+                                        entries: &[
+                                            BindGroupEntry {
+                                                binding: 0,
+                                                resource: BindingResource::TextureView(
+                                                    &gpu_image.texture_view,
+                                                ),
+                                            },
+                                            BindGroupEntry {
+                                                binding: 1,
+                                                resource: BindingResource::Sampler(
+                                                    &gpu_image.sampler,
+                                                ),
+                                            },
+                                        ],
+                                        label: Some("sprite_material_bind_group"),
+                                        layout: &sprite_pipeline.material_layout,
+                                    })
+                                });
+                            existing_batch = batches.last_mut();
+                        } else {
+                            continue;
+                        }
+                    }
+
+                    // Calculate vertex data for this item
+                    let mut uvs = QUAD_UVS;
+                    if extracted_sprite.flip_x {
+                        uvs = [uvs[1], uvs[0], uvs[3], uvs[2]];
+                    }
+                    if extracted_sprite.flip_y {
+                        uvs = [uvs[3], uvs[2], uvs[1], uvs[0]];
+                    }
+
+                    // By default, the size of the quad is the size of the texture
+                    let mut quad_size = batch_image_size;
+
+                    // If a rect is specified, adjust UVs and the size of the quad
+                    if let Some(rect) = extracted_sprite.rect {
+                        let rect_size = rect.size();
+                        for uv in &mut uvs {
+                            *uv = (rect.min + *uv * rect_size) / batch_image_size;
+                        }
+                        quad_size = rect_size;
+                    }
+
+                    // Override the size if a custom one is specified
+                    if let Some(custom_size) = extracted_sprite.custom_size {
+                        quad_size = custom_size;
+                    }
+
+                    // Apply size and global transform
+                    let positions = QUAD_VERTEX_POSITIONS.map(|quad_pos| {
+                        extracted_sprite
+                            .transform
+                            .transform_point(
+                                ((quad_pos - extracted_sprite.anchor) * quad_size).extend(0.),
+                            )
+                            .into()
+                    });
+
+                    // Store the vertex data and add the item to the render phase
+                    if batch_colored {
+                        let vertex_color = extracted_sprite.color.as_linear_rgba_f32();
+                        for i in QUAD_INDICES {
+                            sprite_meta.colored_vertices.push(ColoredSpriteVertex {
+                                position: positions[i],
+                                uv: uvs[i].into(),
+                                color: vertex_color,
                             });
+                        }
+                        colored_index += QUAD_INDICES.len() as u32;
+                        existing_batch.unwrap().1.range.end = colored_index;
                     } else {
-                        // Skip this item if the texture is not ready
-                        continue;
+                        for i in QUAD_INDICES {
+                            sprite_meta.vertices.push(SpriteVertex {
+                                position: positions[i],
+                                uv: uvs[i].into(),
+                            });
+                        }
+                        index += QUAD_INDICES.len() as u32;
+                        existing_batch.unwrap().1.range.end = index;
                     }
-                }
-
-                // Calculate vertex data for this item
-
-                let mut uvs = QUAD_UVS;
-                if extracted_sprite.flip_x {
-                    uvs = [uvs[1], uvs[0], uvs[3], uvs[2]];
-                }
-                if extracted_sprite.flip_y {
-                    uvs = [uvs[3], uvs[2], uvs[1], uvs[0]];
-                }
-
-                // By default, the size of the quad is the size of the texture
-                let mut quad_size = current_image_size;
-
-                // If a rect is specified, adjust UVs and the size of the quad
-                if let Some(rect) = extracted_sprite.rect {
-                    let rect_size = rect.size();
-                    for uv in &mut uvs {
-                        *uv = (rect.min + *uv * rect_size) / current_image_size;
-                    }
-                    quad_size = rect_size;
-                }
-
-                // Override the size if a custom one is specified
-                if let Some(custom_size) = extracted_sprite.custom_size {
-                    quad_size = custom_size;
-                }
-
-                // Apply size and global transform
-                let positions = QUAD_VERTEX_POSITIONS.map(|quad_pos| {
-                    extracted_sprite
-                        .transform
-                        .transform_point(
-                            ((quad_pos - extracted_sprite.anchor) * quad_size).extend(0.),
-                        )
-                        .into()
-                });
-
-                // These items will be sorted by depth with other phase items
-                let sort_key = FloatOrd(extracted_sprite.transform.translation().z);
-
-                // Store the vertex data and add the item to the render phase
-                if current_batch.colored {
-                    let vertex_color = extracted_sprite.color.as_linear_rgba_f32();
-                    for i in QUAD_INDICES {
-                        sprite_meta.colored_vertices.push(ColoredSpriteVertex {
-                            position: positions[i],
-                            uv: uvs[i].into(),
-                            color: vertex_color,
-                        });
-                    }
-                    let item_start = colored_index;
-                    colored_index += QUAD_INDICES.len() as u32;
-                    let item_end = colored_index;
-
-                    transparent_phase.add(Transparent2d {
-                        draw_function: draw_sprite_function,
-                        pipeline: colored_pipeline,
-                        entity: current_batch_entity,
-                        sort_key,
-                        batch_range: Some(item_start..item_end),
-                    });
+                    transparent_phase.items[batch_item_index].batch_size += 1;
                 } else {
-                    for i in QUAD_INDICES {
-                        sprite_meta.vertices.push(SpriteVertex {
-                            position: positions[i],
-                            uv: uvs[i].into(),
-                        });
-                    }
-                    let item_start = index;
-                    index += QUAD_INDICES.len() as u32;
-                    let item_end = index;
-
-                    transparent_phase.add(Transparent2d {
-                        draw_function: draw_sprite_function,
-                        pipeline,
-                        entity: current_batch_entity,
-                        sort_key,
-                        batch_range: Some(item_start..item_end),
-                    });
+                    batch_image_handle = HandleId::Id(Uuid::nil(), u64::MAX);
                 }
             }
         }
@@ -746,7 +764,10 @@ pub fn queue_sprites(
         sprite_meta
             .colored_vertices
             .write_buffer(&render_device, &render_queue);
+        *previous_len = batches.len();
+        commands.insert_or_spawn_batch(batches);
     }
+    extracted_sprites.sprites.clear();
 }
 
 pub type DrawSprite = (
@@ -786,7 +807,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetSpriteTextureBindGrou
     fn render<'w>(
         _item: &P,
         _view: (),
-        sprite_batch: &'_ SpriteBatch,
+        batch: &'_ SpriteBatch,
         image_bind_groups: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
@@ -796,7 +817,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetSpriteTextureBindGrou
             I,
             image_bind_groups
                 .values
-                .get(&Handle::weak(sprite_batch.image_handle_id))
+                .get(&Handle::weak(batch.image_handle_id))
                 .unwrap(),
             &[],
         );
@@ -805,25 +826,25 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetSpriteTextureBindGrou
 }
 
 pub struct DrawSpriteBatch;
-impl<P: BatchedPhaseItem> RenderCommand<P> for DrawSpriteBatch {
+impl<P: PhaseItem> RenderCommand<P> for DrawSpriteBatch {
     type Param = SRes<SpriteMeta>;
     type ViewWorldQuery = ();
     type ItemWorldQuery = Read<SpriteBatch>;
 
     fn render<'w>(
-        item: &P,
+        _item: &P,
         _view: (),
-        sprite_batch: &'_ SpriteBatch,
+        batch: &'_ SpriteBatch,
         sprite_meta: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
         let sprite_meta = sprite_meta.into_inner();
-        if sprite_batch.colored {
+        if batch.colored {
             pass.set_vertex_buffer(0, sprite_meta.colored_vertices.buffer().unwrap().slice(..));
         } else {
             pass.set_vertex_buffer(0, sprite_meta.vertices.buffer().unwrap().slice(..));
         }
-        pass.draw(item.batch_range().as_ref().unwrap().clone(), 0..1);
+        pass.draw(batch.range.clone(), 0..1);
         RenderCommandResult::Success
     }
 }

--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -84,7 +84,7 @@ impl GlyphBrush {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let text_bounds = compute_text_bounds(&glyphs, |index| &sections_data[index].3);
+        let text_bounds = compute_text_bounds(&glyphs, |index| sections_data[index].3);
 
         let mut positioned_glyphs = Vec::new();
         for sg in glyphs {
@@ -203,12 +203,12 @@ impl GlyphPlacementAdjuster {
 
 /// Computes the minimal bounding rectangle for a block of text.
 /// Ignores empty trailing lines.
-pub(crate) fn compute_text_bounds<'a, T>(
+pub(crate) fn compute_text_bounds<T>(
     section_glyphs: &[SectionGlyph],
-    get_scaled_font: impl Fn(usize) -> &'a PxScaleFont<T>,
+    get_scaled_font: impl Fn(usize) -> PxScaleFont<T>,
 ) -> bevy_math::Rect
 where
-    T: ab_glyph::Font + 'a,
+    T: ab_glyph::Font,
 {
     let mut text_bounds = Rect {
         min: Vec2::splat(std::f32::MAX),

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -1,4 +1,4 @@
-use ab_glyph::PxScale;
+use ab_glyph::{Font as AbglyphFont, PxScale};
 use bevy_asset::{Assets, Handle, HandleId};
 use bevy_ecs::component::Component;
 use bevy_ecs::system::Resource;
@@ -7,12 +7,12 @@ use bevy_render::texture::Image;
 use bevy_sprite::TextureAtlas;
 use bevy_utils::HashMap;
 
-use glyph_brush_layout::{FontId, GlyphPositioner, SectionGeometry, SectionText};
+use glyph_brush_layout::{FontId, GlyphPositioner, SectionGeometry, SectionText, ToSectionText};
 
 use crate::{
     compute_text_bounds, error::TextError, glyph_brush::GlyphBrush, scale_value, BreakLineOn, Font,
-    FontAtlasSet, FontAtlasWarning, PositionedGlyph, TextAlignment, TextSection, TextSettings,
-    YAxisOrientation,
+    FontAtlasSet, FontAtlasWarning, PositionedGlyph, Text, TextAlignment, TextSection,
+    TextSettings, YAxisOrientation,
 };
 
 #[derive(Default, Resource)]
@@ -85,7 +85,7 @@ impl TextPipeline {
             return Ok(TextLayoutInfo::default());
         }
 
-        let size = compute_text_bounds(&section_glyphs, |index| &scaled_fonts[index]).size();
+        let size = compute_text_bounds(&section_glyphs, |index| scaled_fonts[index]).size();
 
         let glyphs = self.brush.process_glyphs(
             section_glyphs,
@@ -101,123 +101,110 @@ impl TextPipeline {
 
         Ok(TextLayoutInfo { glyphs, size })
     }
-
-    pub fn create_text_measure(
-        &mut self,
-        fonts: &Assets<Font>,
-        sections: &[TextSection],
-        scale_factor: f64,
-        text_alignment: TextAlignment,
-        linebreak_behaviour: BreakLineOn,
-    ) -> Result<TextMeasureInfo, TextError> {
-        let mut auto_fonts = Vec::with_capacity(sections.len());
-        let mut scaled_fonts = Vec::with_capacity(sections.len());
-        let sections = sections
-            .iter()
-            .enumerate()
-            .map(|(i, section)| {
-                let font = fonts
-                    .get(&section.style.font)
-                    .ok_or(TextError::NoSuchFont)?;
-                let font_size = scale_value(section.style.font_size, scale_factor);
-                auto_fonts.push(font.font.clone());
-                let px_scale_font = ab_glyph::Font::into_scaled(font.font.clone(), font_size);
-                scaled_fonts.push(px_scale_font);
-
-                let section = TextMeasureSection {
-                    font_id: FontId(i),
-                    scale: PxScale::from(font_size),
-                    text: section.value.clone(),
-                };
-
-                Ok(section)
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        Ok(TextMeasureInfo::new(
-            auto_fonts,
-            scaled_fonts,
-            sections,
-            text_alignment,
-            linebreak_behaviour.into(),
-        ))
-    }
 }
 
 #[derive(Debug, Clone)]
 pub struct TextMeasureSection {
-    pub text: String,
-    pub scale: PxScale,
+    pub text: Box<str>,
+    pub scale: f32,
     pub font_id: FontId,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct TextMeasureInfo {
-    pub fonts: Vec<ab_glyph::FontArc>,
-    pub scaled_fonts: Vec<ab_glyph::PxScaleFont<ab_glyph::FontArc>>,
-    pub sections: Vec<TextMeasureSection>,
+    pub fonts: Box<[ab_glyph::FontArc]>,
+    pub sections: Box<[TextMeasureSection]>,
     pub text_alignment: TextAlignment,
-    pub linebreak_behaviour: glyph_brush_layout::BuiltInLineBreaker,
-    pub min_width_content_size: Vec2,
-    pub max_width_content_size: Vec2,
+    pub linebreak_behavior: glyph_brush_layout::BuiltInLineBreaker,
+    pub min: Vec2,
+    pub max: Vec2,
 }
 
 impl TextMeasureInfo {
+    pub fn from_text(
+        text: &Text,
+        fonts: &Assets<Font>,
+        scale_factor: f64,
+    ) -> Result<TextMeasureInfo, TextError> {
+        let sections = &text.sections;
+        for section in sections {
+            if !fonts.contains(&section.style.font) {
+                return Err(TextError::NoSuchFont);
+            }
+        }
+        let (auto_fonts, sections) = sections
+            .iter()
+            .enumerate()
+            .map(|(i, section)| {
+                // SAFETY: we exited early earlier in this function if
+                // one of the fonts was missing.
+                let font = unsafe { fonts.get(&section.style.font).unwrap_unchecked() };
+                (
+                    font.font.clone(),
+                    TextMeasureSection {
+                        font_id: FontId(i),
+                        scale: scale_value(section.style.font_size, scale_factor),
+                        text: section.value.clone().into_boxed_str(),
+                    },
+                )
+            })
+            .unzip();
+
+        Ok(Self::new(
+            auto_fonts,
+            sections,
+            text.alignment,
+            text.linebreak_behavior.into(),
+        ))
+    }
     fn new(
         fonts: Vec<ab_glyph::FontArc>,
-        scaled_fonts: Vec<ab_glyph::PxScaleFont<ab_glyph::FontArc>>,
         sections: Vec<TextMeasureSection>,
         text_alignment: TextAlignment,
-        linebreak_behaviour: glyph_brush_layout::BuiltInLineBreaker,
+        linebreak_behavior: glyph_brush_layout::BuiltInLineBreaker,
     ) -> Self {
         let mut info = Self {
-            fonts,
-            scaled_fonts,
-            sections,
+            fonts: fonts.into_boxed_slice(),
+            sections: sections.into_boxed_slice(),
             text_alignment,
-            linebreak_behaviour,
-            min_width_content_size: Vec2::ZERO,
-            max_width_content_size: Vec2::ZERO,
+            linebreak_behavior,
+            min: Vec2::ZERO,
+            max: Vec2::ZERO,
         };
 
-        let section_texts = info.prepare_section_texts();
-        let min =
-            info.compute_size_from_section_texts(&section_texts, Vec2::new(0.0, f32::INFINITY));
-        let max = info.compute_size_from_section_texts(
-            &section_texts,
-            Vec2::new(f32::INFINITY, f32::INFINITY),
-        );
-        info.min_width_content_size = min;
-        info.max_width_content_size = max;
+        let min = info.compute_size(Vec2::new(0.0, f32::INFINITY));
+        let max = info.compute_size(Vec2::INFINITY);
+        info.min = min;
+        info.max = max;
         info
     }
 
-    fn prepare_section_texts(&self) -> Vec<SectionText> {
-        self.sections
-            .iter()
-            .map(|section| SectionText {
-                font_id: section.font_id,
-                scale: section.scale,
-                text: &section.text,
-            })
-            .collect::<Vec<_>>()
-    }
-
-    fn compute_size_from_section_texts(&self, sections: &[SectionText], bounds: Vec2) -> Vec2 {
+    pub fn compute_size(&self, bounds: Vec2) -> Vec2 {
+        let sections = &self.sections;
         let geom = SectionGeometry {
             bounds: (bounds.x, bounds.y),
             ..Default::default()
         };
         let section_glyphs = glyph_brush_layout::Layout::default()
             .h_align(self.text_alignment.into())
-            .line_breaker(self.linebreak_behaviour)
+            .line_breaker(self.linebreak_behavior)
             .calculate_glyphs(&self.fonts, &geom, sections);
 
-        compute_text_bounds(&section_glyphs, |index| &self.scaled_fonts[index]).size()
+        compute_text_bounds(&section_glyphs, |index| {
+            let font = &self.fonts[index];
+            let font_size = self.sections[index].scale;
+            font.into_scaled(font_size)
+        })
+        .size()
     }
-
-    pub fn compute_size(&self, bounds: Vec2) -> Vec2 {
-        let sections = self.prepare_section_texts();
-        self.compute_size_from_section_texts(&sections, bounds)
+}
+impl ToSectionText for TextMeasureSection {
+    #[inline(always)]
+    fn to_section_text(&self) -> SectionText<'_> {
+        SectionText {
+            text: &self.text,
+            scale: PxScale::from(self.scale),
+            font_id: self.font_id,
+        }
     }
 }

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -140,11 +140,12 @@ impl TextSection {
 }
 
 /// Describes horizontal alignment preference for positioning & bounds.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
 #[reflect(Serialize, Deserialize)]
 pub enum TextAlignment {
     /// Leftmost character is immediately to the right of the render position.<br/>
     /// Bounds start from the render position and advance rightwards.
+    #[default]
     Left,
     /// Leftmost & rightmost characters are equidistant to the render position.<br/>
     /// Bounds start from the render position and advance equally left & right.

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -7,7 +7,7 @@ use bevy_ecs::{
     event::EventReader,
     prelude::With,
     reflect::ReflectComponent,
-    system::{Local, Query, Res, ResMut},
+    system::{Commands, Local, Query, Res, ResMut},
 };
 use bevy_math::{Vec2, Vec3};
 use bevy_reflect::Reflect;
@@ -77,12 +77,12 @@ pub struct Text2dBundle {
 }
 
 pub fn extract_text2d_sprite(
+    mut commands: Commands,
     mut extracted_sprites: ResMut<ExtractedSprites>,
     texture_atlases: Extract<Res<Assets<TextureAtlas>>>,
     windows: Extract<Query<&Window, With<PrimaryWindow>>>,
     text2d_query: Extract<
         Query<(
-            Entity,
             &ComputedVisibility,
             &Text,
             &TextLayoutInfo,
@@ -98,7 +98,7 @@ pub fn extract_text2d_sprite(
         .unwrap_or(1.0);
     let scaling = GlobalTransform::from_scale(Vec3::splat(scale_factor.recip()));
 
-    for (entity, computed_visibility, text, text_layout_info, anchor, global_transform) in
+    for (computed_visibility, text, text_layout_info, anchor, global_transform) in
         text2d_query.iter()
     {
         if !computed_visibility.is_visible() {
@@ -125,17 +125,19 @@ pub fn extract_text2d_sprite(
             }
             let atlas = texture_atlases.get(&atlas_info.texture_atlas).unwrap();
 
-            extracted_sprites.sprites.push(ExtractedSprite {
-                entity,
-                transform: transform * GlobalTransform::from_translation(position.extend(0.)),
-                color,
-                rect: Some(atlas.textures[atlas_info.glyph_index]),
-                custom_size: None,
-                image_handle_id: atlas.texture.id(),
-                flip_x: false,
-                flip_y: false,
-                anchor: Anchor::Center.as_vec(),
-            });
+            extracted_sprites.sprites.insert(
+                commands.spawn_empty().id(),
+                ExtractedSprite {
+                    transform: transform * GlobalTransform::from_translation(position.extend(0.)),
+                    color,
+                    rect: Some(atlas.textures[atlas_info.glyph_index]),
+                    custom_size: None,
+                    image_handle_id: atlas.texture.id(),
+                    flip_x: false,
+                    flip_y: false,
+                    anchor: Anchor::Center.as_vec(),
+                },
+            );
         }
     }
 }

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -124,7 +124,7 @@ impl Time {
     ///     world.insert_resource(time);
     ///     world.insert_resource(Health { health_value: 0.2 });
     ///
-    ///     let mut schedule = Schedule::new();
+    ///     let mut schedule = Schedule::default();
     ///     schedule.add_systems(health_system);
     ///
     ///     // Simulate that 30 ms have passed

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -200,7 +200,7 @@ mod test {
         let offset_transform =
             |offset| TransformBundle::from_transform(Transform::from_xyz(offset, offset, offset));
 
-        let mut schedule = Schedule::new();
+        let mut schedule = Schedule::default();
         schedule.add_systems((sync_simple_transforms, propagate_transforms));
 
         let mut command_queue = CommandQueue::default();
@@ -251,7 +251,7 @@ mod test {
         ComputeTaskPool::init(TaskPool::default);
         let mut world = World::default();
 
-        let mut schedule = Schedule::new();
+        let mut schedule = Schedule::default();
         schedule.add_systems((sync_simple_transforms, propagate_transforms));
 
         // Root entity
@@ -289,7 +289,7 @@ mod test {
     fn did_propagate_command_buffer() {
         let mut world = World::default();
 
-        let mut schedule = Schedule::new();
+        let mut schedule = Schedule::default();
         schedule.add_systems((sync_simple_transforms, propagate_transforms));
 
         // Root entity
@@ -329,7 +329,7 @@ mod test {
         ComputeTaskPool::init(TaskPool::default);
         let mut world = World::default();
 
-        let mut schedule = Schedule::new();
+        let mut schedule = Schedule::default();
         schedule.add_systems((sync_simple_transforms, propagate_transforms));
 
         // Add parent entities

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -60,10 +60,17 @@ pub struct UiRect {
 
 impl UiRect {
     pub const DEFAULT: Self = Self {
-        left: Val::Px(0.),
-        right: Val::Px(0.),
-        top: Val::Px(0.),
-        bottom: Val::Px(0.),
+        left: Val::ZERO,
+        right: Val::ZERO,
+        top: Val::ZERO,
+        bottom: Val::ZERO,
+    };
+
+    pub const ZERO: Self = Self {
+        left: Val::ZERO,
+        right: Val::ZERO,
+        top: Val::ZERO,
+        bottom: Val::ZERO,
     };
 
     /// Creates a new [`UiRect`] from the values specified.
@@ -166,7 +173,7 @@ impl UiRect {
     }
 
     /// Creates a new [`UiRect`] where `left` and `right` take the given value,
-    /// and `top` and `bottom` set to zero `Val::Px(0.)`.
+    /// and `top` and `bottom` set to zero `Val::ZERO`.
     ///
     /// # Example
     ///
@@ -177,8 +184,8 @@ impl UiRect {
     ///
     /// assert_eq!(ui_rect.left, Val::Px(10.0));
     /// assert_eq!(ui_rect.right, Val::Px(10.0));
-    /// assert_eq!(ui_rect.top, Val::Px(0.));
-    /// assert_eq!(ui_rect.bottom, Val::Px(0.));
+    /// assert_eq!(ui_rect.top, Val::ZERO);
+    /// assert_eq!(ui_rect.bottom, Val::ZERO);
     /// ```
     pub fn horizontal(value: Val) -> Self {
         UiRect {
@@ -189,7 +196,7 @@ impl UiRect {
     }
 
     /// Creates a new [`UiRect`] where `top` and `bottom` take the given value,
-    /// and `left` and `right` are set to `Val::Px(0.)`.
+    /// and `left` and `right` are set to `Val::ZERO`.
     ///
     /// # Example
     ///
@@ -198,8 +205,8 @@ impl UiRect {
     /// #
     /// let ui_rect = UiRect::vertical(Val::Px(10.0));
     ///
-    /// assert_eq!(ui_rect.left, Val::Px(0.));
-    /// assert_eq!(ui_rect.right, Val::Px(0.));
+    /// assert_eq!(ui_rect.left, Val::ZERO);
+    /// assert_eq!(ui_rect.right, Val::ZERO);
     /// assert_eq!(ui_rect.top, Val::Px(10.0));
     /// assert_eq!(ui_rect.bottom, Val::Px(10.0));
     /// ```
@@ -235,7 +242,7 @@ impl UiRect {
     }
 
     /// Creates a new [`UiRect`] where `left` takes the given value, and
-    /// the other fields are set to `Val::Px(0.)`.
+    /// the other fields are set to `Val::ZERO`.
     ///
     /// # Example
     ///
@@ -245,9 +252,9 @@ impl UiRect {
     /// let ui_rect = UiRect::left(Val::Px(10.0));
     ///
     /// assert_eq!(ui_rect.left, Val::Px(10.0));
-    /// assert_eq!(ui_rect.right, Val::Px(0.));
-    /// assert_eq!(ui_rect.top, Val::Px(0.));
-    /// assert_eq!(ui_rect.bottom, Val::Px(0.));
+    /// assert_eq!(ui_rect.right, Val::ZERO);
+    /// assert_eq!(ui_rect.top, Val::ZERO);
+    /// assert_eq!(ui_rect.bottom, Val::ZERO);
     /// ```
     pub fn left(value: Val) -> Self {
         UiRect {
@@ -257,7 +264,7 @@ impl UiRect {
     }
 
     /// Creates a new [`UiRect`] where `right` takes the given value,
-    /// and the other fields are set to `Val::Px(0.)`.
+    /// and the other fields are set to `Val::ZERO`.
     ///
     /// # Example
     ///
@@ -266,10 +273,10 @@ impl UiRect {
     /// #
     /// let ui_rect = UiRect::right(Val::Px(10.0));
     ///
-    /// assert_eq!(ui_rect.left, Val::Px(0.));
+    /// assert_eq!(ui_rect.left, Val::ZERO);
     /// assert_eq!(ui_rect.right, Val::Px(10.0));
-    /// assert_eq!(ui_rect.top, Val::Px(0.));
-    /// assert_eq!(ui_rect.bottom, Val::Px(0.));
+    /// assert_eq!(ui_rect.top, Val::ZERO);
+    /// assert_eq!(ui_rect.bottom, Val::ZERO);
     /// ```
     pub fn right(value: Val) -> Self {
         UiRect {
@@ -279,7 +286,7 @@ impl UiRect {
     }
 
     /// Creates a new [`UiRect`] where `top` takes the given value,
-    /// and the other fields are set to `Val::Px(0.)`.
+    /// and the other fields are set to `Val::ZERO`.
     ///
     /// # Example
     ///
@@ -288,10 +295,10 @@ impl UiRect {
     /// #
     /// let ui_rect = UiRect::top(Val::Px(10.0));
     ///
-    /// assert_eq!(ui_rect.left, Val::Px(0.));
-    /// assert_eq!(ui_rect.right, Val::Px(0.));
+    /// assert_eq!(ui_rect.left, Val::ZERO);
+    /// assert_eq!(ui_rect.right, Val::ZERO);
     /// assert_eq!(ui_rect.top, Val::Px(10.0));
-    /// assert_eq!(ui_rect.bottom, Val::Px(0.));
+    /// assert_eq!(ui_rect.bottom, Val::ZERO);
     /// ```
     pub fn top(value: Val) -> Self {
         UiRect {
@@ -301,7 +308,7 @@ impl UiRect {
     }
 
     /// Creates a new [`UiRect`] where `bottom` takes the given value,
-    /// and the other fields are set to `Val::Px(0.)`.
+    /// and the other fields are set to `Val::ZERO`.
     ///
     /// # Example
     ///
@@ -310,9 +317,9 @@ impl UiRect {
     /// #
     /// let ui_rect = UiRect::bottom(Val::Px(10.0));
     ///
-    /// assert_eq!(ui_rect.left, Val::Px(0.));
-    /// assert_eq!(ui_rect.right, Val::Px(0.));
-    /// assert_eq!(ui_rect.top, Val::Px(0.));
+    /// assert_eq!(ui_rect.left, Val::ZERO);
+    /// assert_eq!(ui_rect.right, Val::ZERO);
+    /// assert_eq!(ui_rect.top, Val::ZERO);
     /// assert_eq!(ui_rect.bottom, Val::Px(10.0));
     /// ```
     pub fn bottom(value: Val) -> Self {
@@ -338,10 +345,10 @@ mod tests {
         assert_eq!(
             UiRect::default(),
             UiRect {
-                left: Val::Px(0.),
-                right: Val::Px(0.),
-                top: Val::Px(0.),
-                bottom: Val::Px(0.)
+                left: Val::ZERO,
+                right: Val::ZERO,
+                top: Val::ZERO,
+                bottom: Val::ZERO
             }
         );
         assert_eq!(UiRect::default(), UiRect::DEFAULT);

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -278,8 +278,8 @@ impl From<GridAutoFlow> for taffy::style::GridAutoFlow {
 
 impl From<GridPlacement> for taffy::geometry::Line<taffy::style::GridPlacement> {
     fn from(value: GridPlacement) -> Self {
-        let span = value.span.unwrap_or(1).max(1);
-        match (value.start, value.end) {
+        let span = value.get_span().unwrap_or(1);
+        match (value.get_start(), value.get_end()) {
             (Some(start), Some(end)) => taffy::geometry::Line {
                 start: style_helpers::line(start),
                 end: style_helpers::line(end),

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -397,14 +397,15 @@ mod tests {
 
     #[test]
     fn test_convert_from() {
+        use sh::TaffyZero;
         use taffy::style_helpers as sh;
 
         let bevy_style = crate::Style {
             display: Display::Flex,
             position_type: PositionType::Absolute,
-            left: Val::Px(0.),
-            right: Val::Percent(0.),
-            top: Val::Auto,
+            left: Val::ZERO,
+            right: Val::Percent(50.),
+            top: Val::Px(12.),
             bottom: Val::Auto,
             direction: crate::Direction::Inherit,
             flex_direction: FlexDirection::ColumnReverse,
@@ -416,36 +417,36 @@ mod tests {
             justify_self: JustifySelf::Center,
             justify_content: JustifyContent::SpaceEvenly,
             margin: UiRect {
-                left: Val::Percent(0.),
-                right: Val::Px(0.),
-                top: Val::Auto,
+                left: Val::ZERO,
+                right: Val::Px(10.),
+                top: Val::Percent(15.),
                 bottom: Val::Auto,
             },
             padding: UiRect {
-                left: Val::Percent(0.),
-                right: Val::Px(0.),
-                top: Val::Percent(0.),
-                bottom: Val::Percent(0.),
+                left: Val::Percent(13.),
+                right: Val::Px(21.),
+                top: Val::Auto,
+                bottom: Val::ZERO,
             },
             border: UiRect {
-                left: Val::Px(0.),
-                right: Val::Px(0.),
+                left: Val::Px(14.),
+                right: Val::ZERO,
                 top: Val::Auto,
-                bottom: Val::Px(0.),
+                bottom: Val::Percent(31.),
             },
             flex_grow: 1.,
             flex_shrink: 0.,
-            flex_basis: Val::Px(0.),
-            width: Val::Px(0.),
+            flex_basis: Val::ZERO,
+            width: Val::ZERO,
             height: Val::Auto,
-            min_width: Val::Px(0.),
-            min_height: Val::Percent(0.),
+            min_width: Val::ZERO,
+            min_height: Val::ZERO,
             max_width: Val::Auto,
-            max_height: Val::Px(0.),
+            max_height: Val::ZERO,
             aspect_ratio: None,
             overflow: crate::Overflow::clip(),
-            column_gap: Val::Px(0.),
-            row_gap: Val::Percent(0.),
+            column_gap: Val::ZERO,
+            row_gap: Val::ZERO,
             grid_auto_flow: GridAutoFlow::ColumnDense,
             grid_template_rows: vec![
                 GridTrack::px(10.0),
@@ -470,22 +471,22 @@ mod tests {
         let taffy_style = from_style(&viewport_values, &bevy_style);
         assert_eq!(taffy_style.display, taffy::style::Display::Flex);
         assert_eq!(taffy_style.position, taffy::style::Position::Absolute);
-        assert!(matches!(
+        assert_eq!(
             taffy_style.inset.left,
-            taffy::style::LengthPercentageAuto::Points(_)
-        ));
-        assert!(matches!(
+            taffy::style::LengthPercentageAuto::ZERO
+        );
+        assert_eq!(
             taffy_style.inset.right,
-            taffy::style::LengthPercentageAuto::Percent(_)
-        ));
-        assert!(matches!(
+            taffy::style::LengthPercentageAuto::Percent(0.5)
+        );
+        assert_eq!(
             taffy_style.inset.top,
-            taffy::style::LengthPercentageAuto::Auto
-        ));
-        assert!(matches!(
+            taffy::style::LengthPercentageAuto::Points(12.)
+        );
+        assert_eq!(
             taffy_style.inset.bottom,
             taffy::style::LengthPercentageAuto::Auto
-        ));
+        );
         assert_eq!(
             taffy_style.flex_direction,
             taffy::style::FlexDirection::ColumnReverse
@@ -509,93 +510,63 @@ mod tests {
             taffy_style.justify_self,
             Some(taffy::style::JustifySelf::Center)
         );
-        assert!(matches!(
+        assert_eq!(
             taffy_style.margin.left,
-            taffy::style::LengthPercentageAuto::Percent(_)
-        ));
-        assert!(matches!(
+            taffy::style::LengthPercentageAuto::ZERO
+        );
+        assert_eq!(
             taffy_style.margin.right,
-            taffy::style::LengthPercentageAuto::Points(_)
-        ));
-        assert!(matches!(
+            taffy::style::LengthPercentageAuto::Points(10.)
+        );
+        assert_eq!(
             taffy_style.margin.top,
-            taffy::style::LengthPercentageAuto::Auto
-        ));
-        assert!(matches!(
+            taffy::style::LengthPercentageAuto::Percent(0.15)
+        );
+        assert_eq!(
             taffy_style.margin.bottom,
             taffy::style::LengthPercentageAuto::Auto
-        ));
-        assert!(matches!(
+        );
+        assert_eq!(
             taffy_style.padding.left,
-            taffy::style::LengthPercentage::Percent(_)
-        ));
-        assert!(matches!(
+            taffy::style::LengthPercentage::Percent(0.13)
+        );
+        assert_eq!(
             taffy_style.padding.right,
-            taffy::style::LengthPercentage::Points(_)
-        ));
-        assert!(matches!(
+            taffy::style::LengthPercentage::Points(21.)
+        );
+        assert_eq!(
             taffy_style.padding.top,
-            taffy::style::LengthPercentage::Percent(_)
-        ));
-        assert!(matches!(
+            taffy::style::LengthPercentage::ZERO
+        );
+        assert_eq!(
             taffy_style.padding.bottom,
-            taffy::style::LengthPercentage::Percent(_)
-        ));
-        assert!(matches!(
+            taffy::style::LengthPercentage::ZERO
+        );
+        assert_eq!(
             taffy_style.border.left,
-            taffy::style::LengthPercentage::Points(_)
-        ));
-        assert!(matches!(
+            taffy::style::LengthPercentage::Points(14.)
+        );
+        assert_eq!(
             taffy_style.border.right,
-            taffy::style::LengthPercentage::Points(_)
-        ));
-        assert!(matches!(
-            taffy_style.border.top,
-            taffy::style::LengthPercentage::Points(_)
-        ));
-        assert!(matches!(
+            taffy::style::LengthPercentage::ZERO
+        );
+        assert_eq!(taffy_style.border.top, taffy::style::LengthPercentage::ZERO);
+        assert_eq!(
             taffy_style.border.bottom,
-            taffy::style::LengthPercentage::Points(_)
-        ));
+            taffy::style::LengthPercentage::Percent(0.31)
+        );
         assert_eq!(taffy_style.flex_grow, 1.);
         assert_eq!(taffy_style.flex_shrink, 0.);
-        assert!(matches!(
-            taffy_style.flex_basis,
-            taffy::style::Dimension::Points(_)
-        ));
-        assert!(matches!(
-            taffy_style.size.width,
-            taffy::style::Dimension::Points(_)
-        ));
-        assert!(matches!(
-            taffy_style.size.height,
-            taffy::style::Dimension::Auto
-        ));
-        assert!(matches!(
-            taffy_style.min_size.width,
-            taffy::style::Dimension::Points(_)
-        ));
-        assert!(matches!(
-            taffy_style.min_size.height,
-            taffy::style::Dimension::Percent(_)
-        ));
-        assert!(matches!(
-            taffy_style.max_size.width,
-            taffy::style::Dimension::Auto
-        ));
-        assert!(matches!(
-            taffy_style.max_size.height,
-            taffy::style::Dimension::Points(_)
-        ));
+        assert_eq!(taffy_style.flex_basis, taffy::style::Dimension::ZERO);
+        assert_eq!(taffy_style.size.width, taffy::style::Dimension::ZERO);
+        assert_eq!(taffy_style.size.height, taffy::style::Dimension::Auto);
+        assert_eq!(taffy_style.min_size.width, taffy::style::Dimension::ZERO);
+        assert_eq!(taffy_style.min_size.height, taffy::style::Dimension::ZERO);
+        assert_eq!(taffy_style.max_size.width, taffy::style::Dimension::Auto);
+        assert_eq!(taffy_style.max_size.height, taffy::style::Dimension::ZERO);
         assert_eq!(taffy_style.aspect_ratio, None);
-        assert_eq!(
-            taffy_style.gap.width,
-            taffy::style::LengthPercentage::Points(0.)
-        );
-        assert_eq!(
-            taffy_style.gap.height,
-            taffy::style::LengthPercentage::Percent(0.)
-        );
+        assert_eq!(taffy_style.gap.width, taffy::style::LengthPercentage::ZERO);
+        assert_eq!(taffy_style.gap.height, taffy::style::LengthPercentage::ZERO);
         assert_eq!(
             taffy_style.grid_auto_flow,
             taffy::style::GridAutoFlow::ColumnDense

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -36,12 +36,12 @@ pub struct NodeBundle {
     pub focus_policy: FocusPolicy,
     /// The transform of the node
     ///
-    /// This field is automatically managed by the UI layout system.
+    /// This component is automatically managed by the UI layout system.
     /// To alter the position of the `NodeBundle`, use the properties of the [`Style`] component.
     pub transform: Transform,
     /// The global transform of the node
     ///
-    /// This field is automatically managed by the UI layout system.
+    /// This component is automatically updated by the [`TransformPropagate`](`bevy_transform::TransformSystem::TransformPropagate`) systems.
     /// To alter the position of the `NodeBundle`, use the properties of the [`Style`] component.
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
@@ -88,19 +88,18 @@ pub struct ImageBundle {
     pub image: UiImage,
     /// The size of the image in pixels
     ///
-    /// This field is set automatically
+    /// This component is set automatically
     pub image_size: UiImageSize,
     /// Whether this node should block interaction with lower nodes
     pub focus_policy: FocusPolicy,
     /// The transform of the node
     ///
-    /// This field is automatically managed by the UI layout system.
+    /// This component is automatically managed by the UI layout system.
     /// To alter the position of the `ImageBundle`, use the properties of the [`Style`] component.
     pub transform: Transform,
     /// The global transform of the node
     ///
-    /// This field is automatically managed by the UI layout system.
-    /// To alter the position of the `ImageBundle`, use the properties of the [`Style`] component.
+    /// This component is automatically updated by the [`TransformPropagate`](`bevy_transform::TransformSystem::TransformPropagate`) systems.
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,
@@ -132,17 +131,16 @@ pub struct AtlasImageBundle {
     pub focus_policy: FocusPolicy,
     /// The size of the image in pixels
     ///
-    /// This field is set automatically
+    /// This component is set automatically
     pub image_size: UiImageSize,
     /// The transform of the node
     ///
-    /// This field is automatically managed by the UI layout system.
+    /// This component is automatically managed by the UI layout system.
     /// To alter the position of the `AtlasImageBundle`, use the properties of the [`Style`] component.
     pub transform: Transform,
     /// The global transform of the node
     ///
-    /// This field is automatically managed by the UI layout system.
-    /// To alter the position of the `AtlasImageBundle`, use the properties of the [`Style`] component.
+    /// This component is automatically updated by the [`TransformPropagate`](`bevy_transform::TransformSystem::TransformPropagate`) systems.
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,
@@ -173,13 +171,12 @@ pub struct TextBundle {
     pub focus_policy: FocusPolicy,
     /// The transform of the node
     ///
-    /// This field is automatically managed by the UI layout system.
+    /// This component is automatically managed by the UI layout system.
     /// To alter the position of the `TextBundle`, use the properties of the [`Style`] component.
     pub transform: Transform,
     /// The global transform of the node
     ///
-    /// This field is automatically managed by the UI layout system.
-    /// To alter the position of the `TextBundle`, use the properties of the [`Style`] component.
+    /// This component is automatically updated by the [`TransformPropagate`](`bevy_transform::TransformSystem::TransformPropagate`) systems.
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,
@@ -285,13 +282,12 @@ pub struct ButtonBundle {
     pub image: UiImage,
     /// The transform of the node
     ///
-    /// This field is automatically managed by the UI layout system.
+    /// This component is automatically managed by the UI layout system.
     /// To alter the position of the `ButtonBundle`, use the properties of the [`Style`] component.
     pub transform: Transform,
     /// The global transform of the node
     ///
-    /// This field is automatically managed by the UI layout system.
-    /// To alter the position of the `ButtonBundle`, use the properties of the [`Style`] component.
+    /// This component is automatically updated by the [`TransformPropagate`](`bevy_transform::TransformSystem::TransformPropagate`) systems.
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -2,6 +2,7 @@ mod pipeline;
 mod render_pass;
 
 use bevy_core_pipeline::{core_2d::Camera2d, core_3d::Camera3d};
+use bevy_ecs::storage::SparseSet;
 use bevy_hierarchy::Parent;
 use bevy_render::{ExtractSchedule, Render};
 use bevy_window::{PrimaryWindow, Window};
@@ -14,7 +15,7 @@ use crate::{
 };
 
 use bevy_app::prelude::*;
-use bevy_asset::{load_internal_asset, AssetEvent, Assets, Handle, HandleUntyped};
+use bevy_asset::{load_internal_asset, AssetEvent, Assets, Handle, HandleId, HandleUntyped};
 use bevy_ecs::prelude::*;
 use bevy_math::{Mat4, Rect, URect, UVec4, Vec2, Vec3, Vec4Swizzles};
 use bevy_reflect::TypeUuid;
@@ -36,8 +37,8 @@ use bevy_sprite::TextureAtlas;
 #[cfg(feature = "bevy_text")]
 use bevy_text::{PositionedGlyph, Text, TextLayoutInfo};
 use bevy_transform::components::GlobalTransform;
-use bevy_utils::FloatOrd;
 use bevy_utils::HashMap;
+use bevy_utils::{FloatOrd, Uuid};
 use bytemuck::{Pod, Zeroable};
 use std::ops::Range;
 
@@ -93,9 +94,9 @@ pub fn build_ui_render(app: &mut App) {
         .add_systems(
             Render,
             (
-                prepare_uinodes.in_set(RenderSet::Prepare),
                 queue_uinodes.in_set(RenderSet::Queue),
                 sort_phase_system::<TransparentUi>.in_set(RenderSet::PhaseSort),
+                prepare_uinodes.in_set(RenderSet::PrepareBindGroups),
             ),
         );
 
@@ -166,7 +167,7 @@ pub struct ExtractedUiNode {
 
 #[derive(Resource, Default)]
 pub struct ExtractedUiNodes {
-    pub uinodes: Vec<ExtractedUiNode>,
+    pub uinodes: SparseSet<Entity, ExtractedUiNode>,
 }
 
 pub fn extract_atlas_uinodes(
@@ -177,6 +178,7 @@ pub fn extract_atlas_uinodes(
     uinode_query: Extract<
         Query<
             (
+                Entity,
                 &Node,
                 &GlobalTransform,
                 &BackgroundColor,
@@ -190,8 +192,16 @@ pub fn extract_atlas_uinodes(
     >,
 ) {
     for (stack_index, entity) in ui_stack.uinodes.iter().enumerate() {
-        if let Ok((uinode, transform, color, visibility, clip, texture_atlas_handle, atlas_image)) =
-            uinode_query.get(*entity)
+        if let Ok((
+            entity,
+            uinode,
+            transform,
+            color,
+            visibility,
+            clip,
+            texture_atlas_handle,
+            atlas_image,
+        )) = uinode_query.get(*entity)
         {
             // Skip invisible and completely transparent nodes
             if !visibility.is_visible() || color.0.a() == 0.0 {
@@ -230,17 +240,20 @@ pub fn extract_atlas_uinodes(
             atlas_rect.max *= scale;
             atlas_size *= scale;
 
-            extracted_uinodes.uinodes.push(ExtractedUiNode {
-                stack_index,
-                transform: transform.compute_matrix(),
-                color: color.0,
-                rect: atlas_rect,
-                clip: clip.map(|clip| clip.clip),
-                image,
-                atlas_size: Some(atlas_size),
-                flip_x: atlas_image.flip_x,
-                flip_y: atlas_image.flip_y,
-            });
+            extracted_uinodes.uinodes.insert(
+                entity,
+                ExtractedUiNode {
+                    stack_index,
+                    transform: transform.compute_matrix(),
+                    color: color.0,
+                    rect: atlas_rect,
+                    clip: clip.map(|clip| clip.clip),
+                    image,
+                    atlas_size: Some(atlas_size),
+                    flip_x: atlas_image.flip_x,
+                    flip_y: atlas_image.flip_y,
+                },
+            );
         }
     }
 }
@@ -258,6 +271,7 @@ fn resolve_border_thickness(value: Val, parent_width: f32, viewport_size: Vec2) 
 }
 
 pub fn extract_uinode_borders(
+    mut commands: Commands,
     mut extracted_uinodes: ResMut<ExtractedUiNodes>,
     windows: Extract<Query<&Window, With<PrimaryWindow>>>,
     ui_scale: Extract<Res<UiScale>>,
@@ -355,21 +369,24 @@ pub fn extract_uinode_borders(
 
             for edge in border_rects {
                 if edge.min.x < edge.max.x && edge.min.y < edge.max.y {
-                    extracted_uinodes.uinodes.push(ExtractedUiNode {
-                        stack_index,
-                        // This translates the uinode's transform to the center of the current border rectangle
-                        transform: transform * Mat4::from_translation(edge.center().extend(0.)),
-                        color: border_color.0,
-                        rect: Rect {
-                            max: edge.size(),
-                            ..Default::default()
+                    extracted_uinodes.uinodes.insert(
+                        commands.spawn_empty().id(),
+                        ExtractedUiNode {
+                            stack_index,
+                            // This translates the uinode's transform to the center of the current border rectangle
+                            transform: transform * Mat4::from_translation(edge.center().extend(0.)),
+                            color: border_color.0,
+                            rect: Rect {
+                                max: edge.size(),
+                                ..Default::default()
+                            },
+                            image: image.clone_weak(),
+                            atlas_size: None,
+                            clip: clip.map(|clip| clip.clip),
+                            flip_x: false,
+                            flip_y: false,
                         },
-                        image: image.clone_weak(),
-                        atlas_size: None,
-                        clip: clip.map(|clip| clip.clip),
-                        flip_x: false,
-                        flip_y: false,
-                    });
+                    );
                 }
             }
         }
@@ -383,6 +400,7 @@ pub fn extract_uinodes(
     uinode_query: Extract<
         Query<
             (
+                Entity,
                 &Node,
                 &GlobalTransform,
                 &BackgroundColor,
@@ -395,7 +413,7 @@ pub fn extract_uinodes(
     >,
 ) {
     for (stack_index, entity) in ui_stack.uinodes.iter().enumerate() {
-        if let Ok((uinode, transform, color, maybe_image, visibility, clip)) =
+        if let Ok((entity, uinode, transform, color, maybe_image, visibility, clip)) =
             uinode_query.get(*entity)
         {
             // Skip invisible and completely transparent nodes
@@ -413,20 +431,23 @@ pub fn extract_uinodes(
                 (DEFAULT_IMAGE_HANDLE.typed(), false, false)
             };
 
-            extracted_uinodes.uinodes.push(ExtractedUiNode {
-                stack_index,
-                transform: transform.compute_matrix(),
-                color: color.0,
-                rect: Rect {
-                    min: Vec2::ZERO,
-                    max: uinode.calculated_size,
+            extracted_uinodes.uinodes.insert(
+                entity,
+                ExtractedUiNode {
+                    stack_index,
+                    transform: transform.compute_matrix(),
+                    color: color.0,
+                    rect: Rect {
+                        min: Vec2::ZERO,
+                        max: uinode.calculated_size,
+                    },
+                    clip: clip.map(|clip| clip.clip),
+                    image,
+                    atlas_size: None,
+                    flip_x,
+                    flip_y,
                 },
-                clip: clip.map(|clip| clip.clip),
-                image,
-                atlas_size: None,
-                flip_x,
-                flip_y,
-            });
+            );
         };
     }
 }
@@ -506,6 +527,7 @@ pub fn extract_default_ui_camera_view<T: Component>(
 
 #[cfg(feature = "bevy_text")]
 pub fn extract_text_uinodes(
+    mut commands: Commands,
     mut extracted_uinodes: ResMut<ExtractedUiNodes>,
     texture_atlases: Extract<Res<Assets<TextureAtlas>>>,
     windows: Extract<Query<&Window, With<PrimaryWindow>>>,
@@ -560,18 +582,21 @@ pub fn extract_text_uinodes(
                 let mut rect = atlas.textures[atlas_info.glyph_index];
                 rect.min *= inverse_scale_factor;
                 rect.max *= inverse_scale_factor;
-                extracted_uinodes.uinodes.push(ExtractedUiNode {
-                    stack_index,
-                    transform: transform
-                        * Mat4::from_translation(position.extend(0.) * inverse_scale_factor),
-                    color,
-                    rect,
-                    image: atlas.texture.clone_weak(),
-                    atlas_size: Some(atlas.size * inverse_scale_factor),
-                    clip: clip.map(|clip| clip.clip),
-                    flip_x: false,
-                    flip_y: false,
-                });
+                extracted_uinodes.uinodes.insert(
+                    commands.spawn_empty().id(),
+                    ExtractedUiNode {
+                        stack_index,
+                        transform: transform
+                            * Mat4::from_translation(position.extend(0.) * inverse_scale_factor),
+                        color,
+                        rect,
+                        image: atlas.texture.clone_weak(),
+                        atlas_size: Some(atlas.size * inverse_scale_factor),
+                        clip: clip.map(|clip| clip.clip),
+                        flip_x: false,
+                        flip_y: false,
+                    },
+                );
             }
         }
     }
@@ -613,176 +638,42 @@ const QUAD_INDICES: [usize; 6] = [0, 2, 3, 0, 1, 2];
 #[derive(Component)]
 pub struct UiBatch {
     pub range: Range<u32>,
-    pub image: Handle<Image>,
-    pub z: f32,
+    pub image_handle_id: HandleId,
 }
 
 const TEXTURED_QUAD: u32 = 0;
 const UNTEXTURED_QUAD: u32 = 1;
 
-pub fn prepare_uinodes(
-    mut commands: Commands,
-    render_device: Res<RenderDevice>,
-    render_queue: Res<RenderQueue>,
-    mut ui_meta: ResMut<UiMeta>,
-    mut extracted_uinodes: ResMut<ExtractedUiNodes>,
+#[allow(clippy::too_many_arguments)]
+pub fn queue_uinodes(
+    extracted_uinodes: Res<ExtractedUiNodes>,
+    ui_pipeline: Res<UiPipeline>,
+    mut pipelines: ResMut<SpecializedRenderPipelines<UiPipeline>>,
+    mut views: Query<(&ExtractedView, &mut RenderPhase<TransparentUi>)>,
+    pipeline_cache: Res<PipelineCache>,
+    draw_functions: Res<DrawFunctions<TransparentUi>>,
 ) {
-    ui_meta.vertices.clear();
-
-    // sort by ui stack index, starting from the deepest node
-    extracted_uinodes
-        .uinodes
-        .sort_by_key(|node| node.stack_index);
-
-    let mut start = 0;
-    let mut end = 0;
-    let mut current_batch_image = DEFAULT_IMAGE_HANDLE.typed();
-    let mut last_z = 0.0;
-
-    #[inline]
-    fn is_textured(image: &Handle<Image>) -> bool {
-        image.id() != DEFAULT_IMAGE_HANDLE.id()
-    }
-
-    for extracted_uinode in extracted_uinodes.uinodes.drain(..) {
-        let mode = if is_textured(&extracted_uinode.image) {
-            if current_batch_image.id() != extracted_uinode.image.id() {
-                if is_textured(&current_batch_image) && start != end {
-                    commands.spawn(UiBatch {
-                        range: start..end,
-                        image: current_batch_image,
-                        z: last_z,
-                    });
-                    start = end;
-                }
-                current_batch_image = extracted_uinode.image.clone_weak();
-            }
-            TEXTURED_QUAD
-        } else {
-            // Untextured `UiBatch`es are never spawned within the loop.
-            // If all the `extracted_uinodes` are untextured a single untextured UiBatch will be spawned after the loop terminates.
-            UNTEXTURED_QUAD
-        };
-
-        let mut uinode_rect = extracted_uinode.rect;
-
-        let rect_size = uinode_rect.size().extend(1.0);
-
-        // Specify the corners of the node
-        let positions = QUAD_VERTEX_POSITIONS
-            .map(|pos| (extracted_uinode.transform * (pos * rect_size).extend(1.)).xyz());
-
-        // Calculate the effect of clipping
-        // Note: this won't work with rotation/scaling, but that's much more complex (may need more that 2 quads)
-        let mut positions_diff = if let Some(clip) = extracted_uinode.clip {
-            [
-                Vec2::new(
-                    f32::max(clip.min.x - positions[0].x, 0.),
-                    f32::max(clip.min.y - positions[0].y, 0.),
-                ),
-                Vec2::new(
-                    f32::min(clip.max.x - positions[1].x, 0.),
-                    f32::max(clip.min.y - positions[1].y, 0.),
-                ),
-                Vec2::new(
-                    f32::min(clip.max.x - positions[2].x, 0.),
-                    f32::min(clip.max.y - positions[2].y, 0.),
-                ),
-                Vec2::new(
-                    f32::max(clip.min.x - positions[3].x, 0.),
-                    f32::min(clip.max.y - positions[3].y, 0.),
-                ),
-            ]
-        } else {
-            [Vec2::ZERO; 4]
-        };
-
-        let positions_clipped = [
-            positions[0] + positions_diff[0].extend(0.),
-            positions[1] + positions_diff[1].extend(0.),
-            positions[2] + positions_diff[2].extend(0.),
-            positions[3] + positions_diff[3].extend(0.),
-        ];
-
-        let transformed_rect_size = extracted_uinode.transform.transform_vector3(rect_size);
-
-        // Don't try to cull nodes that have a rotation
-        // In a rotation around the Z-axis, this value is 0.0 for an angle of 0.0 or π
-        // In those two cases, the culling check can proceed normally as corners will be on
-        // horizontal / vertical lines
-        // For all other angles, bypass the culling check
-        // This does not properly handles all rotations on all axis
-        if extracted_uinode.transform.x_axis[1] == 0.0 {
-            // Cull nodes that are completely clipped
-            if positions_diff[0].x - positions_diff[1].x >= transformed_rect_size.x
-                || positions_diff[1].y - positions_diff[2].y >= transformed_rect_size.y
-            {
-                continue;
-            }
-        }
-        let uvs = if mode == UNTEXTURED_QUAD {
-            [Vec2::ZERO, Vec2::X, Vec2::ONE, Vec2::Y]
-        } else {
-            let atlas_extent = extracted_uinode.atlas_size.unwrap_or(uinode_rect.max);
-            if extracted_uinode.flip_x {
-                std::mem::swap(&mut uinode_rect.max.x, &mut uinode_rect.min.x);
-                positions_diff[0].x *= -1.;
-                positions_diff[1].x *= -1.;
-                positions_diff[2].x *= -1.;
-                positions_diff[3].x *= -1.;
-            }
-            if extracted_uinode.flip_y {
-                std::mem::swap(&mut uinode_rect.max.y, &mut uinode_rect.min.y);
-                positions_diff[0].y *= -1.;
-                positions_diff[1].y *= -1.;
-                positions_diff[2].y *= -1.;
-                positions_diff[3].y *= -1.;
-            }
-            [
-                Vec2::new(
-                    uinode_rect.min.x + positions_diff[0].x,
-                    uinode_rect.min.y + positions_diff[0].y,
-                ),
-                Vec2::new(
-                    uinode_rect.max.x + positions_diff[1].x,
-                    uinode_rect.min.y + positions_diff[1].y,
-                ),
-                Vec2::new(
-                    uinode_rect.max.x + positions_diff[2].x,
-                    uinode_rect.max.y + positions_diff[2].y,
-                ),
-                Vec2::new(
-                    uinode_rect.min.x + positions_diff[3].x,
-                    uinode_rect.max.y + positions_diff[3].y,
-                ),
-            ]
-            .map(|pos| pos / atlas_extent)
-        };
-
-        let color = extracted_uinode.color.as_linear_rgba_f32();
-        for i in QUAD_INDICES {
-            ui_meta.vertices.push(UiVertex {
-                position: positions_clipped[i].into(),
-                uv: uvs[i].into(),
-                color,
-                mode,
+    let draw_function = draw_functions.read().id::<DrawUi>();
+    for (view, mut transparent_phase) in &mut views {
+        let pipeline = pipelines.specialize(
+            &pipeline_cache,
+            &ui_pipeline,
+            UiPipelineKey { hdr: view.hdr },
+        );
+        transparent_phase
+            .items
+            .reserve(extracted_uinodes.uinodes.len());
+        for (entity, extracted_uinode) in extracted_uinodes.uinodes.iter() {
+            transparent_phase.add(TransparentUi {
+                draw_function,
+                pipeline,
+                entity: *entity,
+                sort_key: FloatOrd(extracted_uinode.stack_index as f32),
+                // batch_size will be calculated in prepare_uinodes
+                batch_size: 0,
             });
         }
-
-        last_z = extracted_uinode.transform.w_axis[2];
-        end += QUAD_INDICES.len() as u32;
     }
-
-    // if start != end, there is one last batch to process
-    if start != end {
-        commands.spawn(UiBatch {
-            range: start..end,
-            image: current_batch_image,
-            z: last_z,
-        });
-    }
-
-    ui_meta.vertices.write_buffer(&render_device, &render_queue);
 }
 
 #[derive(Resource, Default)]
@@ -791,19 +682,19 @@ pub struct UiImageBindGroups {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn queue_uinodes(
-    draw_functions: Res<DrawFunctions<TransparentUi>>,
+pub fn prepare_uinodes(
+    mut commands: Commands,
     render_device: Res<RenderDevice>,
+    render_queue: Res<RenderQueue>,
     mut ui_meta: ResMut<UiMeta>,
+    mut extracted_uinodes: ResMut<ExtractedUiNodes>,
     view_uniforms: Res<ViewUniforms>,
     ui_pipeline: Res<UiPipeline>,
-    mut pipelines: ResMut<SpecializedRenderPipelines<UiPipeline>>,
-    pipeline_cache: Res<PipelineCache>,
     mut image_bind_groups: ResMut<UiImageBindGroups>,
     gpu_images: Res<RenderAssets<Image>>,
-    ui_batches: Query<(Entity, &UiBatch)>,
-    mut views: Query<(&ExtractedView, &mut RenderPhase<TransparentUi>)>,
+    mut phases: Query<&mut RenderPhase<TransparentUi>>,
     events: Res<SpriteAssetEvents>,
+    mut previous_len: Local<usize>,
 ) {
     // If an image has changed, the GpuImage has (probably) changed
     for event in &events.images {
@@ -815,7 +706,15 @@ pub fn queue_uinodes(
         };
     }
 
+    #[inline]
+    fn is_textured(image: &Handle<Image>) -> bool {
+        image.id() != DEFAULT_IMAGE_HANDLE.id()
+    }
+
     if let Some(view_binding) = view_uniforms.uniforms.binding() {
+        let mut batches: Vec<(Entity, UiBatch)> = Vec::with_capacity(*previous_len);
+
+        ui_meta.vertices.clear();
         ui_meta.view_bind_group = Some(render_device.create_bind_group(&BindGroupDescriptor {
             entries: &[BindGroupEntry {
                 binding: 0,
@@ -824,41 +723,186 @@ pub fn queue_uinodes(
             label: Some("ui_view_bind_group"),
             layout: &ui_pipeline.view_layout,
         }));
-        let draw_ui_function = draw_functions.read().id::<DrawUi>();
-        for (view, mut transparent_phase) in &mut views {
-            let pipeline = pipelines.specialize(
-                &pipeline_cache,
-                &ui_pipeline,
-                UiPipelineKey { hdr: view.hdr },
-            );
-            for (entity, batch) in &ui_batches {
-                image_bind_groups
-                    .values
-                    .entry(batch.image.clone_weak())
-                    .or_insert_with(|| {
-                        let gpu_image = gpu_images.get(&batch.image).unwrap();
-                        render_device.create_bind_group(&BindGroupDescriptor {
-                            entries: &[
-                                BindGroupEntry {
-                                    binding: 0,
-                                    resource: BindingResource::TextureView(&gpu_image.texture_view),
-                                },
-                                BindGroupEntry {
-                                    binding: 1,
-                                    resource: BindingResource::Sampler(&gpu_image.sampler),
-                                },
-                            ],
-                            label: Some("ui_material_bind_group"),
-                            layout: &ui_pipeline.image_layout,
-                        })
+
+        // Vertex buffer index
+        let mut index = 0;
+
+        for mut ui_phase in &mut phases {
+            let mut batch_item_index = 0;
+            let mut batch_image_handle = HandleId::Id(Uuid::nil(), u64::MAX);
+
+            for item_index in 0..ui_phase.items.len() {
+                let item = &mut ui_phase.items[item_index];
+                if let Some(extracted_uinode) = extracted_uinodes.uinodes.get(item.entity) {
+                    let mut existing_batch = batches
+                        .last_mut()
+                        .filter(|_| batch_image_handle == extracted_uinode.image.id());
+
+                    if existing_batch.is_none() {
+                        if let Some(gpu_image) = gpu_images.get(&extracted_uinode.image) {
+                            batch_item_index = item_index;
+                            batch_image_handle = extracted_uinode.image.id();
+
+                            let new_batch = UiBatch {
+                                range: index..index,
+                                image_handle_id: extracted_uinode.image.id(),
+                            };
+
+                            batches.push((item.entity, new_batch));
+
+                            image_bind_groups
+                                .values
+                                .entry(Handle::weak(batch_image_handle))
+                                .or_insert_with(|| {
+                                    render_device.create_bind_group(&BindGroupDescriptor {
+                                        entries: &[
+                                            BindGroupEntry {
+                                                binding: 0,
+                                                resource: BindingResource::TextureView(
+                                                    &gpu_image.texture_view,
+                                                ),
+                                            },
+                                            BindGroupEntry {
+                                                binding: 1,
+                                                resource: BindingResource::Sampler(
+                                                    &gpu_image.sampler,
+                                                ),
+                                            },
+                                        ],
+                                        label: Some("ui_material_bind_group"),
+                                        layout: &ui_pipeline.image_layout,
+                                    })
+                                });
+
+                            existing_batch = batches.last_mut();
+                        } else {
+                            continue;
+                        }
+                    }
+
+                    let mode = if is_textured(&extracted_uinode.image) {
+                        TEXTURED_QUAD
+                    } else {
+                        UNTEXTURED_QUAD
+                    };
+
+                    let mut uinode_rect = extracted_uinode.rect;
+
+                    let rect_size = uinode_rect.size().extend(1.0);
+
+                    // Specify the corners of the node
+                    let positions = QUAD_VERTEX_POSITIONS.map(|pos| {
+                        (extracted_uinode.transform * (pos * rect_size).extend(1.)).xyz()
                     });
-                transparent_phase.add(TransparentUi {
-                    draw_function: draw_ui_function,
-                    pipeline,
-                    entity,
-                    sort_key: FloatOrd(batch.z),
-                });
+
+                    // Calculate the effect of clipping
+                    // Note: this won't work with rotation/scaling, but that's much more complex (may need more that 2 quads)
+                    let mut positions_diff = if let Some(clip) = extracted_uinode.clip {
+                        [
+                            Vec2::new(
+                                f32::max(clip.min.x - positions[0].x, 0.),
+                                f32::max(clip.min.y - positions[0].y, 0.),
+                            ),
+                            Vec2::new(
+                                f32::min(clip.max.x - positions[1].x, 0.),
+                                f32::max(clip.min.y - positions[1].y, 0.),
+                            ),
+                            Vec2::new(
+                                f32::min(clip.max.x - positions[2].x, 0.),
+                                f32::min(clip.max.y - positions[2].y, 0.),
+                            ),
+                            Vec2::new(
+                                f32::max(clip.min.x - positions[3].x, 0.),
+                                f32::min(clip.max.y - positions[3].y, 0.),
+                            ),
+                        ]
+                    } else {
+                        [Vec2::ZERO; 4]
+                    };
+
+                    let positions_clipped = [
+                        positions[0] + positions_diff[0].extend(0.),
+                        positions[1] + positions_diff[1].extend(0.),
+                        positions[2] + positions_diff[2].extend(0.),
+                        positions[3] + positions_diff[3].extend(0.),
+                    ];
+
+                    let transformed_rect_size =
+                        extracted_uinode.transform.transform_vector3(rect_size);
+
+                    // Don't try to cull nodes that have a rotation
+                    // In a rotation around the Z-axis, this value is 0.0 for an angle of 0.0 or π
+                    // In those two cases, the culling check can proceed normally as corners will be on
+                    // horizontal / vertical lines
+                    // For all other angles, bypass the culling check
+                    // This does not properly handles all rotations on all axis
+                    if extracted_uinode.transform.x_axis[1] == 0.0 {
+                        // Cull nodes that are completely clipped
+                        if positions_diff[0].x - positions_diff[1].x >= transformed_rect_size.x
+                            || positions_diff[1].y - positions_diff[2].y >= transformed_rect_size.y
+                        {
+                            continue;
+                        }
+                    }
+                    let uvs = if mode == UNTEXTURED_QUAD {
+                        [Vec2::ZERO, Vec2::X, Vec2::ONE, Vec2::Y]
+                    } else {
+                        let atlas_extent = extracted_uinode.atlas_size.unwrap_or(uinode_rect.max);
+                        if extracted_uinode.flip_x {
+                            std::mem::swap(&mut uinode_rect.max.x, &mut uinode_rect.min.x);
+                            positions_diff[0].x *= -1.;
+                            positions_diff[1].x *= -1.;
+                            positions_diff[2].x *= -1.;
+                            positions_diff[3].x *= -1.;
+                        }
+                        if extracted_uinode.flip_y {
+                            std::mem::swap(&mut uinode_rect.max.y, &mut uinode_rect.min.y);
+                            positions_diff[0].y *= -1.;
+                            positions_diff[1].y *= -1.;
+                            positions_diff[2].y *= -1.;
+                            positions_diff[3].y *= -1.;
+                        }
+                        [
+                            Vec2::new(
+                                uinode_rect.min.x + positions_diff[0].x,
+                                uinode_rect.min.y + positions_diff[0].y,
+                            ),
+                            Vec2::new(
+                                uinode_rect.max.x + positions_diff[1].x,
+                                uinode_rect.min.y + positions_diff[1].y,
+                            ),
+                            Vec2::new(
+                                uinode_rect.max.x + positions_diff[2].x,
+                                uinode_rect.max.y + positions_diff[2].y,
+                            ),
+                            Vec2::new(
+                                uinode_rect.min.x + positions_diff[3].x,
+                                uinode_rect.max.y + positions_diff[3].y,
+                            ),
+                        ]
+                        .map(|pos| pos / atlas_extent)
+                    };
+
+                    let color = extracted_uinode.color.as_linear_rgba_f32();
+                    for i in QUAD_INDICES {
+                        ui_meta.vertices.push(UiVertex {
+                            position: positions_clipped[i].into(),
+                            uv: uvs[i].into(),
+                            color,
+                            mode,
+                        });
+                    }
+                    index += QUAD_INDICES.len() as u32;
+                    existing_batch.unwrap().1.range.end = index;
+                    ui_phase.items[batch_item_index].batch_size += 1;
+                } else {
+                    batch_image_handle = HandleId::Id(Uuid::nil(), u64::MAX);
+                }
             }
         }
+        ui_meta.vertices.write_buffer(&render_device, &render_queue);
+        *previous_len = batches.len();
+        commands.insert_or_spawn_batch(batches);
     }
+    extracted_uinodes.uinodes.clear();
 }

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -1,5 +1,6 @@
 use super::{UiBatch, UiImageBindGroups, UiMeta};
 use crate::{prelude::UiCameraConfig, DefaultCameraView};
+use bevy_asset::Handle;
 use bevy_ecs::{
     prelude::*,
     system::{lifetimeless::*, SystemParamItem},
@@ -90,6 +91,7 @@ pub struct TransparentUi {
     pub entity: Entity,
     pub pipeline: CachedRenderPipelineId,
     pub draw_function: DrawFunctionId,
+    pub batch_size: usize,
 }
 
 impl PhaseItem for TransparentUi {
@@ -108,6 +110,11 @@ impl PhaseItem for TransparentUi {
     #[inline]
     fn draw_function(&self) -> DrawFunctionId {
         self.draw_function
+    }
+
+    #[inline]
+    fn batch_size(&self) -> usize {
+        self.batch_size
     }
 }
 
@@ -161,7 +168,14 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetUiTextureBindGroup<I>
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
         let image_bind_groups = image_bind_groups.into_inner();
-        pass.set_bind_group(I, image_bind_groups.values.get(&batch.image).unwrap(), &[]);
+        pass.set_bind_group(
+            I,
+            image_bind_groups
+                .values
+                .get(&Handle::weak(batch.image_handle_id))
+                .unwrap(),
+            &[],
+        );
         RenderCommandResult::Success
     }
 }

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -113,6 +113,11 @@ impl PhaseItem for TransparentUi {
     }
 
     #[inline]
+    fn sort(items: &mut [Self]) {
+        items.sort_by_key(|item| item.sort_key());
+    }
+
+    #[inline]
     fn batch_size(&self) -> usize {
         self.batch_size
     }

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -49,10 +49,10 @@ impl Node for UiPassNode {
         let input_view_entity = graph.view_entity();
 
         let Ok((transparent_phase, target, camera_ui)) =
-                self.ui_view_query.get_manual(world, input_view_entity)
-             else {
-                return Ok(());
-            };
+            self.ui_view_query.get_manual(world, input_view_entity)
+        else {
+            return Ok(());
+        };
         if transparent_phase.items.is_empty() {
             return Ok(());
         }

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -237,42 +237,6 @@ pub enum ValArithmeticError {
 }
 
 impl Val {
-    /// Tries to add the values of two [`Val`]s.
-    /// Returns [`ValArithmeticError::NonIdenticalVariants`] if two [`Val`]s are of different variants.
-    /// When adding non-numeric [`Val`]s, it returns the value unchanged.
-    pub fn try_add(&self, rhs: Val) -> Result<Val, ValArithmeticError> {
-        match (self, rhs) {
-            (Val::Auto, Val::Auto) => Ok(*self),
-            (Val::Px(value), Val::Px(rhs_value)) => Ok(Val::Px(value + rhs_value)),
-            (Val::Percent(value), Val::Percent(rhs_value)) => Ok(Val::Percent(value + rhs_value)),
-            _ => Err(ValArithmeticError::NonIdenticalVariants),
-        }
-    }
-
-    /// Adds `rhs` to `self` and assigns the result to `self` (see [`Val::try_add`])
-    pub fn try_add_assign(&mut self, rhs: Val) -> Result<(), ValArithmeticError> {
-        *self = self.try_add(rhs)?;
-        Ok(())
-    }
-
-    /// Tries to subtract the values of two [`Val`]s.
-    /// Returns [`ValArithmeticError::NonIdenticalVariants`] if two [`Val`]s are of different variants.
-    /// When adding non-numeric [`Val`]s, it returns the value unchanged.
-    pub fn try_sub(&self, rhs: Val) -> Result<Val, ValArithmeticError> {
-        match (self, rhs) {
-            (Val::Auto, Val::Auto) => Ok(*self),
-            (Val::Px(value), Val::Px(rhs_value)) => Ok(Val::Px(value - rhs_value)),
-            (Val::Percent(value), Val::Percent(rhs_value)) => Ok(Val::Percent(value - rhs_value)),
-            _ => Err(ValArithmeticError::NonIdenticalVariants),
-        }
-    }
-
-    /// Subtracts `rhs` from `self` and assigns the result to `self` (see [`Val::try_sub`])
-    pub fn try_sub_assign(&mut self, rhs: Val) -> Result<(), ValArithmeticError> {
-        *self = self.try_sub(rhs)?;
-        Ok(())
-    }
-
     /// A convenience function for simple evaluation of [`Val::Percent`] variant into a concrete [`Val::Px`] value.
     /// Returns a [`ValArithmeticError::NonEvaluateable`] if the [`Val`] is impossible to evaluate into [`Val::Px`].
     /// Otherwise it returns an [`f32`] containing the evaluated value in pixels.
@@ -284,46 +248,6 @@ impl Val {
             Val::Px(value) => Ok(*value),
             _ => Err(ValArithmeticError::NonEvaluateable),
         }
-    }
-
-    /// Similar to [`Val::try_add`], but performs [`Val::evaluate`] on both values before adding.
-    /// Returns an [`f32`] value in pixels.
-    pub fn try_add_with_size(&self, rhs: Val, size: f32) -> Result<f32, ValArithmeticError> {
-        let lhs = self.evaluate(size)?;
-        let rhs = rhs.evaluate(size)?;
-
-        Ok(lhs + rhs)
-    }
-
-    /// Similar to [`Val::try_add_assign`], but performs [`Val::evaluate`] on both values before adding.
-    /// The value gets converted to [`Val::Px`].
-    pub fn try_add_assign_with_size(
-        &mut self,
-        rhs: Val,
-        size: f32,
-    ) -> Result<(), ValArithmeticError> {
-        *self = Val::Px(self.evaluate(size)? + rhs.evaluate(size)?);
-        Ok(())
-    }
-
-    /// Similar to [`Val::try_sub`], but performs [`Val::evaluate`] on both values before subtracting.
-    /// Returns an [`f32`] value in pixels.
-    pub fn try_sub_with_size(&self, rhs: Val, size: f32) -> Result<f32, ValArithmeticError> {
-        let lhs = self.evaluate(size)?;
-        let rhs = rhs.evaluate(size)?;
-
-        Ok(lhs - rhs)
-    }
-
-    /// Similar to [`Val::try_sub_assign`], but performs [`Val::evaluate`] on both values before adding.
-    /// The value gets converted to [`Val::Px`].
-    pub fn try_sub_assign_with_size(
-        &mut self,
-        rhs: Val,
-        size: f32,
-    ) -> Result<(), ValArithmeticError> {
-        *self = Val::Px(self.try_add_with_size(rhs, size)?);
-        Ok(())
     }
 }
 
@@ -1796,67 +1720,6 @@ mod tests {
     use super::Val;
 
     #[test]
-    fn val_try_add() {
-        let auto_sum = Val::Auto.try_add(Val::Auto).unwrap();
-        let px_sum = Val::Px(20.).try_add(Val::Px(22.)).unwrap();
-        let percent_sum = Val::Percent(50.).try_add(Val::Percent(50.)).unwrap();
-
-        assert_eq!(auto_sum, Val::Auto);
-        assert_eq!(px_sum, Val::Px(42.));
-        assert_eq!(percent_sum, Val::Percent(100.));
-    }
-
-    #[test]
-    fn val_try_add_to_self() {
-        let mut val = Val::Px(5.);
-
-        val.try_add_assign(Val::Px(3.)).unwrap();
-
-        assert_eq!(val, Val::Px(8.));
-    }
-
-    #[test]
-    fn val_try_sub() {
-        let auto_sum = Val::Auto.try_sub(Val::Auto).unwrap();
-        let px_sum = Val::Px(72.).try_sub(Val::Px(30.)).unwrap();
-        let percent_sum = Val::Percent(100.).try_sub(Val::Percent(50.)).unwrap();
-
-        assert_eq!(auto_sum, Val::Auto);
-        assert_eq!(px_sum, Val::Px(42.));
-        assert_eq!(percent_sum, Val::Percent(50.));
-    }
-
-    #[test]
-    fn different_variant_val_try_add() {
-        let different_variant_sum_1 = Val::Px(50.).try_add(Val::Percent(50.));
-        let different_variant_sum_2 = Val::Percent(50.).try_add(Val::Auto);
-
-        assert_eq!(
-            different_variant_sum_1,
-            Err(ValArithmeticError::NonIdenticalVariants)
-        );
-        assert_eq!(
-            different_variant_sum_2,
-            Err(ValArithmeticError::NonIdenticalVariants)
-        );
-    }
-
-    #[test]
-    fn different_variant_val_try_sub() {
-        let different_variant_diff_1 = Val::Px(50.).try_sub(Val::Percent(50.));
-        let different_variant_diff_2 = Val::Percent(50.).try_sub(Val::Auto);
-
-        assert_eq!(
-            different_variant_diff_1,
-            Err(ValArithmeticError::NonIdenticalVariants)
-        );
-        assert_eq!(
-            different_variant_diff_2,
-            Err(ValArithmeticError::NonIdenticalVariants)
-        );
-    }
-
-    #[test]
     fn val_evaluate() {
         let size = 250.;
         let result = Val::Percent(80.).evaluate(size).unwrap();
@@ -1878,49 +1741,6 @@ mod tests {
         let evaluate_auto = Val::Auto.evaluate(size);
 
         assert_eq!(evaluate_auto, Err(ValArithmeticError::NonEvaluateable));
-    }
-
-    #[test]
-    fn val_try_add_with_size() {
-        let size = 250.;
-
-        let px_sum = Val::Px(21.).try_add_with_size(Val::Px(21.), size).unwrap();
-        let percent_sum = Val::Percent(20.)
-            .try_add_with_size(Val::Percent(30.), size)
-            .unwrap();
-        let mixed_sum = Val::Px(20.)
-            .try_add_with_size(Val::Percent(30.), size)
-            .unwrap();
-
-        assert_eq!(px_sum, 42.);
-        assert_eq!(percent_sum, 0.5 * size);
-        assert_eq!(mixed_sum, 20. + 0.3 * size);
-    }
-
-    #[test]
-    fn val_try_sub_with_size() {
-        let size = 250.;
-
-        let px_sum = Val::Px(60.).try_sub_with_size(Val::Px(18.), size).unwrap();
-        let percent_sum = Val::Percent(80.)
-            .try_sub_with_size(Val::Percent(30.), size)
-            .unwrap();
-        let mixed_sum = Val::Percent(50.)
-            .try_sub_with_size(Val::Px(30.), size)
-            .unwrap();
-
-        assert_eq!(px_sum, 42.);
-        assert_eq!(percent_sum, 0.5 * size);
-        assert_eq!(mixed_sum, 0.5 * size - 30.);
-    }
-
-    #[test]
-    fn val_try_add_non_numeric_with_size() {
-        let size = 250.;
-
-        let percent_sum = Val::Auto.try_add_with_size(Val::Auto, size);
-
-        assert_eq!(percent_sum, Err(ValArithmeticError::NonEvaluateable));
     }
 
     #[test]

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -53,20 +53,17 @@ impl Measure for TextMeasure {
         _available_height: AvailableSpace,
     ) -> Vec2 {
         let x = width.unwrap_or_else(|| match available_width {
-            AvailableSpace::Definite(x) => x.clamp(
-                self.info.min_width_content_size.x,
-                self.info.max_width_content_size.x,
-            ),
-            AvailableSpace::MinContent => self.info.min_width_content_size.x,
-            AvailableSpace::MaxContent => self.info.max_width_content_size.x,
+            AvailableSpace::Definite(x) => x.clamp(self.info.min.x, self.info.max.x),
+            AvailableSpace::MinContent => self.info.min.x,
+            AvailableSpace::MaxContent => self.info.max.x,
         });
 
         height
             .map_or_else(
                 || match available_width {
                     AvailableSpace::Definite(_) => self.info.compute_size(Vec2::new(x, f32::MAX)),
-                    AvailableSpace::MinContent => Vec2::new(x, self.info.min_width_content_size.y),
-                    AvailableSpace::MaxContent => Vec2::new(x, self.info.max_width_content_size.y),
+                    AvailableSpace::MinContent => Vec2::new(x, self.info.min.y),
+                    AvailableSpace::MaxContent => Vec2::new(x, self.info.max.y),
                 },
                 |y| Vec2::new(x, y),
             )
@@ -77,24 +74,15 @@ impl Measure for TextMeasure {
 #[inline]
 fn create_text_measure(
     fonts: &Assets<Font>,
-    text_pipeline: &mut TextPipeline,
     scale_factor: f64,
     text: Ref<Text>,
     mut content_size: Mut<ContentSize>,
     mut text_flags: Mut<TextFlags>,
 ) {
-    match text_pipeline.create_text_measure(
-        fonts,
-        &text.sections,
-        scale_factor,
-        text.alignment,
-        text.linebreak_behavior,
-    ) {
+    match TextMeasureInfo::from_text(&text, fonts, scale_factor) {
         Ok(measure) => {
             if text.linebreak_behavior == BreakLineOn::NoWrap {
-                content_size.set(FixedMeasure {
-                    size: measure.max_width_content_size,
-                });
+                content_size.set(FixedMeasure { size: measure.max });
             } else {
                 content_size.set(TextMeasure { info: measure });
             }
@@ -127,7 +115,6 @@ pub fn measure_text_system(
     fonts: Res<Assets<Font>>,
     windows: Query<&Window, With<PrimaryWindow>>,
     ui_scale: Res<UiScale>,
-    mut text_pipeline: ResMut<TextPipeline>,
     mut text_query: Query<(Ref<Text>, &mut ContentSize, &mut TextFlags), With<Node>>,
 ) {
     let window_scale_factor = windows
@@ -142,14 +129,7 @@ pub fn measure_text_system(
         // scale factor unchanged, only create new measure funcs for modified text
         for (text, content_size, text_flags) in text_query.iter_mut() {
             if text.is_changed() || text_flags.needs_new_measure_func {
-                create_text_measure(
-                    &fonts,
-                    &mut text_pipeline,
-                    scale_factor,
-                    text,
-                    content_size,
-                    text_flags,
-                );
+                create_text_measure(&fonts, scale_factor, text, content_size, text_flags);
             }
         }
     } else {
@@ -157,14 +137,7 @@ pub fn measure_text_system(
         *last_scale_factor = scale_factor;
 
         for (text, content_size, text_flags) in text_query.iter_mut() {
-            create_text_measure(
-                &fonts,
-                &mut text_pipeline,
-                scale_factor,
-                text,
-                content_size,
-                text_flags,
-            );
+            create_text_measure(&fonts, scale_factor, text, content_size, text_flags);
         }
     }
 }

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -298,6 +298,30 @@ impl<F: FnOnce()> Drop for OnDrop<F> {
     }
 }
 
+/// Calls the [`tracing::info!`] macro on a value.
+pub fn info<T: Debug>(data: T) {
+    tracing::info!("{:?}", data);
+}
+
+/// Calls the [`tracing::debug!`] macro on a value.
+pub fn dbg<T: Debug>(data: T) {
+    tracing::debug!("{:?}", data);
+}
+
+/// Processes a [`Result`] by calling the [`tracing::warn!`] macro in case of an [`Err`] value.
+pub fn warn<E: Debug>(result: Result<(), E>) {
+    if let Err(warn) = result {
+        tracing::warn!("{:?}", warn);
+    }
+}
+
+/// Processes a [`Result`] by calling the [`tracing::error!`] macro in case of an [`Err`] value.
+pub fn error<E: Debug>(result: Result<(), E>) {
+    if let Err(error) = result {
+        tracing::error!("{:?}", error);
+    }
+}
+
 /// Like [`tracing::trace`], but conditional on cargo feature `detailed_trace`.
 #[macro_export]
 macro_rules! detailed_trace {

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -2,7 +2,7 @@ use bevy_ecs::{
     entity::{Entity, EntityMapper, MapEntities},
     prelude::{Component, ReflectComponent},
 };
-use bevy_math::{DVec2, IVec2, Vec2};
+use bevy_math::{DVec2, IVec2, Rect, Vec2};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 
 #[cfg(feature = "serialize")]
@@ -316,9 +316,8 @@ impl Window {
     /// See [`WindowResolution`] for an explanation about logical/physical sizes.
     #[inline]
     pub fn cursor_position(&self) -> Option<Vec2> {
-        self.internal
-            .physical_cursor_position
-            .map(|position| (position / self.scale_factor()).as_vec2())
+        self.physical_cursor_position()
+            .map(|position| (position.as_dvec2() / self.scale_factor()).as_vec2())
     }
 
     /// The cursor position in this window in physical pixels.
@@ -328,9 +327,17 @@ impl Window {
     /// See [`WindowResolution`] for an explanation about logical/physical sizes.
     #[inline]
     pub fn physical_cursor_position(&self) -> Option<Vec2> {
-        self.internal
-            .physical_cursor_position
-            .map(|position| position.as_vec2())
+        match self.internal.physical_cursor_position {
+            Some(position) => {
+                let position = position.as_vec2();
+                if Rect::new(0., 0., self.width(), self.height()).contains(position) {
+                    Some(position)
+                } else {
+                    None
+                }
+            }
+            None => None,
+        }
     }
 
     /// Set the cursor position in this window in logical pixels.

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -422,20 +422,20 @@ pub fn winit_runner(mut app: App) {
                     event_writer_system_state.get_mut(&mut app.world);
 
                 let Some(window_entity) = winit_windows.get_window_entity(window_id) else {
-                        warn!(
-                            "Skipped event {:?} for unknown winit Window Id {:?}",
-                            event, window_id
-                        );
-                        return;
-                    };
+                    warn!(
+                        "Skipped event {:?} for unknown winit Window Id {:?}",
+                        event, window_id
+                    );
+                    return;
+                };
 
                 let Ok((mut window, mut cache)) = windows.get_mut(window_entity) else {
-                        warn!(
-                            "Window {:?} is missing `Window` component, skipping event {:?}",
-                            window_entity, event
-                        );
-                        return;
-                    };
+                    warn!(
+                        "Window {:?} is missing `Window` component, skipping event {:?}",
+                        window_entity, event
+                    );
+                    return;
+                };
 
                 runner_state.window_event_received = true;
 

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -279,7 +279,7 @@ impl Plugin for ColoredMesh2dPlugin {
             .add_render_command::<Transparent2d, DrawColoredMesh2d>()
             .init_resource::<SpecializedRenderPipelines<ColoredMesh2dPipeline>>()
             .add_systems(ExtractSchedule, extract_colored_mesh2d)
-            .add_systems(Render, queue_colored_mesh2d.in_set(RenderSet::Queue));
+            .add_systems(Render, queue_colored_mesh2d.in_set(RenderSet::QueueMeshes));
     }
 
     fn finish(&self, app: &mut App) {
@@ -357,7 +357,7 @@ pub fn queue_colored_mesh2d(
                     // in order to get correct transparency
                     sort_key: FloatOrd(mesh_z),
                     // This material is not batched
-                    batch_range: None,
+                    batch_size: 1,
                 });
             }
         }

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -56,7 +56,10 @@ fn setup(
     for handle in &rpg_sprite_handles.handles {
         let handle = handle.typed_weak();
         let Some(texture) = textures.get(&handle) else {
-            warn!("{:?} did not resolve to an `Image` asset.", asset_server.get_handle_path(handle));
+            warn!(
+                "{:?} did not resolve to an `Image` asset.",
+                asset_server.get_handle_path(handle)
+            );
             continue;
         };
 

--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -237,7 +237,7 @@ fn setup(
                     TextBundle::from_section(label, label_text_style.clone())
                         .with_style(Style {
                             position_type: PositionType::Absolute,
-                            bottom: Val::Px(0.),
+                            bottom: Val::ZERO,
                             ..default()
                         })
                         .with_no_wrap(),

--- a/examples/3d/bloom_3d.rs
+++ b/examples/3d/bloom_3d.rs
@@ -75,7 +75,7 @@ fn setup_scene(
                 0 => material_emissive1.clone(),
                 1 => material_emissive2.clone(),
                 2 => material_emissive3.clone(),
-                3 | 4 | 5 => material_non_emissive.clone(),
+                3..=5 => material_non_emissive.clone(),
                 _ => unreachable!(),
             };
 

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -98,7 +98,7 @@ fn setup(
         style: Style {
             position_type: PositionType::Absolute,
             top: Val::Px(130.0),
-            right: Val::Px(0.0),
+            right: Val::ZERO,
             ..default()
         },
         transform: Transform {

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use bevy::pbr::CascadeShadowConfigBuilder;
 use bevy::prelude::*;
+use bevy_internal::animation::RepeatAnimation;
 
 fn main() {
     App::new()
@@ -77,6 +78,8 @@ fn setup(
     println!("  - spacebar: play / pause");
     println!("  - arrow up / down: speed up / slow down animation playback");
     println!("  - arrow left / right: seek backward / forward");
+    println!("  - digit 1 / 3 / 5: play the animation <digit> times");
+    println!("  - L: loop the animation forever");
     println!("  - return: change animation");
 }
 
@@ -116,13 +119,13 @@ fn keyboard_animation_control(
         }
 
         if keyboard_input.just_pressed(KeyCode::Left) {
-            let elapsed = player.elapsed();
-            player.set_elapsed(elapsed - 0.1);
+            let elapsed = player.seek_time();
+            player.seek_to(elapsed - 0.1);
         }
 
         if keyboard_input.just_pressed(KeyCode::Right) {
-            let elapsed = player.elapsed();
-            player.set_elapsed(elapsed + 0.1);
+            let elapsed = player.seek_time();
+            player.seek_to(elapsed + 0.1);
         }
 
         if keyboard_input.just_pressed(KeyCode::Return) {
@@ -133,6 +136,25 @@ fn keyboard_animation_control(
                     Duration::from_millis(250),
                 )
                 .repeat();
+        }
+
+        if keyboard_input.just_pressed(KeyCode::Key1) {
+            player.set_repeat(RepeatAnimation::Count(1));
+            player.replay();
+        }
+
+        if keyboard_input.just_pressed(KeyCode::Key3) {
+            player.set_repeat(RepeatAnimation::Count(3));
+            player.replay();
+        }
+
+        if keyboard_input.just_pressed(KeyCode::Key5) {
+            player.set_repeat(RepeatAnimation::Count(5));
+            player.replay();
+        }
+
+        if keyboard_input.just_pressed(KeyCode::L) {
+            player.set_repeat(RepeatAnimation::Forever);
         }
     }
 }

--- a/examples/animation/cubic_curve.rs
+++ b/examples/animation/cubic_curve.rs
@@ -33,7 +33,7 @@ fn setup(
     ]];
 
     // Make a CubicCurve
-    let bezier = Bezier::new(points).to_curve();
+    let bezier = CubicBezier::new(points).to_curve();
 
     // Spawning a cube to experiment on
     commands.spawn((

--- a/examples/animation/morph_targets.rs
+++ b/examples/animation/morph_targets.rs
@@ -88,8 +88,12 @@ fn name_morphs(
         return;
     }
 
-    let Some(mesh) = meshes.get(&morph_data.mesh) else { return };
-    let Some(names) = mesh.morph_target_names() else { return };
+    let Some(mesh) = meshes.get(&morph_data.mesh) else {
+        return;
+    };
+    let Some(names) = mesh.morph_target_names() else {
+        return;
+    };
     for name in names {
         println!("  {name}");
     }

--- a/examples/ecs/system_piping.rs
+++ b/examples/ecs/system_piping.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 use std::num::ParseIntError;
 
 use bevy::log::LogPlugin;
-use bevy::utils::tracing::Level;
+use bevy::utils::{dbg, error, info, tracing::Level, warn};
 
 fn main() {
     App::new()
@@ -19,11 +19,11 @@ fn main() {
             Update,
             (
                 parse_message_system.pipe(handler_system),
-                data_pipe_system.pipe(info),
-                parse_message_system.pipe(dbg),
-                warning_pipe_system.pipe(warn),
-                parse_error_message_system.pipe(error),
-                parse_message_system.pipe(ignore),
+                data_pipe_system.map(info),
+                parse_message_system.map(dbg),
+                warning_pipe_system.map(warn),
+                parse_error_message_system.map(error),
+                parse_message_system.map(std::mem::drop),
             ),
         )
         .run();

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -249,11 +249,6 @@ fn setup(
     commands.spawn(WallBundle::new(WallLocation::Top));
 
     // Bricks
-    // Negative scales result in flipped sprites / meshes,
-    // which is definitely not what we want here
-    assert!(BRICK_SIZE.x > 0.0);
-    assert!(BRICK_SIZE.y > 0.0);
-
     let total_width_of_bricks = (RIGHT_WALL - LEFT_WALL) - 2. * GAP_BETWEEN_BRICKS_AND_SIDES;
     let bottom_edge_of_bricks = paddle_y + GAP_BETWEEN_PADDLE_AND_BRICKS;
     let total_height_of_bricks = TOP_WALL - bottom_edge_of_bricks - GAP_BETWEEN_BRICKS_AND_CEILING;

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -74,7 +74,10 @@ impl Plugin for GameOfLifeComputePlugin {
         // for operation on by the compute shader and display on the sprite.
         app.add_plugins(ExtractResourcePlugin::<GameOfLifeImage>::default());
         let render_app = app.sub_app_mut(RenderApp);
-        render_app.add_systems(Render, queue_bind_group.in_set(RenderSet::Queue));
+        render_app.add_systems(
+            Render,
+            prepare_bind_group.in_set(RenderSet::PrepareBindGroups),
+        );
 
         let mut render_graph = render_app.world.resource_mut::<RenderGraph>();
         render_graph.add_node("game_of_life", GameOfLifeNode::default());
@@ -96,7 +99,7 @@ struct GameOfLifeImage(Handle<Image>);
 #[derive(Resource)]
 struct GameOfLifeImageBindGroup(BindGroup);
 
-fn queue_bind_group(
+fn prepare_bind_group(
     mut commands: Commands,
     pipeline: Res<GameOfLifePipeline>,
     gpu_images: Res<RenderAssets<Image>>,

--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -158,7 +158,8 @@ impl ViewNode for PostProcessNode {
         let pipeline_cache = world.resource::<PipelineCache>();
 
         // Get the pipeline from the cache
-        let Some(pipeline) = pipeline_cache.get_render_pipeline(post_process_pipeline.pipeline_id) else {
+        let Some(pipeline) = pipeline_cache.get_render_pipeline(post_process_pipeline.pipeline_id)
+        else {
             return Ok(());
         };
 

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -86,8 +86,8 @@ impl Plugin for CustomMaterialPlugin {
             .add_systems(
                 Render,
                 (
-                    queue_custom.in_set(RenderSet::Queue),
-                    prepare_instance_buffers.in_set(RenderSet::Prepare),
+                    queue_custom.in_set(RenderSet::QueueMeshes),
+                    prepare_instance_buffers.in_set(RenderSet::PrepareResources),
                 ),
             );
     }
@@ -136,6 +136,7 @@ fn queue_custom(
                     draw_function: draw_custom,
                     distance: rangefinder
                         .distance_translation(&mesh_transforms.transform.translation),
+                    batch_size: 1,
                 });
             }
         }

--- a/examples/shader/texture_binding_array.rs
+++ b/examples/shader/texture_binding_array.rs
@@ -37,7 +37,7 @@ impl Plugin for GpuFeatureSupportChecker {
 
     fn finish(&self, app: &mut App) {
         let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
-            return
+            return;
         };
 
         let render_device = render_app.world.resource::<RenderDevice>();

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -270,13 +270,13 @@ fn keyboard_animation_control(
         }
 
         if keyboard_input.just_pressed(KeyCode::Left) {
-            let elapsed = player.elapsed();
-            player.set_elapsed(elapsed - 0.1);
+            let elapsed = player.seek_time();
+            player.seek_to(elapsed - 0.1);
         }
 
         if keyboard_input.just_pressed(KeyCode::Right) {
-            let elapsed = player.elapsed();
-            player.set_elapsed(elapsed + 0.1);
+            let elapsed = player.seek_time();
+            player.seek_to(elapsed + 0.1);
         }
 
         if keyboard_input.just_pressed(KeyCode::Return) {

--- a/examples/stress_tests/many_gizmos.rs
+++ b/examples/stress_tests/many_gizmos.rs
@@ -91,7 +91,10 @@ fn setup(mut commands: Commands) {
 fn ui_system(mut query: Query<&mut Text>, config: Res<Config>, diag: Res<DiagnosticsStore>) {
     let mut text = query.single_mut();
 
-    let Some(fps) = diag.get(FrameTimeDiagnosticsPlugin::FPS).and_then(|fps| fps.smoothed()) else {
+    let Some(fps) = diag
+        .get(FrameTimeDiagnosticsPlugin::FPS)
+        .and_then(|fps| fps.smoothed())
+    else {
         return;
     };
 

--- a/examples/tools/scene_viewer/animation_plugin.rs
+++ b/examples/tools/scene_viewer/animation_plugin.rs
@@ -91,7 +91,7 @@ fn handle_inputs(
 
             let resume = !player.is_paused();
             // set the current animation to its start and pause it to reset to its starting state
-            player.set_elapsed(0.0).pause();
+            player.seek_to(0.0).pause();
 
             clips.advance_to_next();
             let current_clip = clips.current();

--- a/examples/tools/scene_viewer/morph_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/morph_viewer_plugin.rs
@@ -181,7 +181,9 @@ fn update_text(
     mut text: Query<&mut Text>,
     morphs: Query<&MorphWeights>,
 ) {
-    let Some(mut controls) = controls else { return; };
+    let Some(mut controls) = controls else {
+        return;
+    };
     for (i, target) in controls.weights.iter_mut().enumerate() {
         let Ok(weights) = morphs.get(target.entity) else {
             continue;
@@ -203,7 +205,9 @@ fn update_morphs(
     input: Res<Input<KeyCode>>,
     time: Res<Time>,
 ) {
-    let Some(mut controls) = controls else { return; };
+    let Some(mut controls) = controls else {
+        return;
+    };
     for (i, target) in controls.weights.iter_mut().enumerate() {
         if !AVAILABLE_KEYS[i].active(&input) {
             continue;

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -50,7 +50,7 @@ fn atlas_render_system(
                 image: texture_atlas.texture.clone().into(),
                 style: Style {
                     position_type: PositionType::Absolute,
-                    top: Val::Px(0.0),
+                    top: Val::ZERO,
                     left: Val::Px(512.0 * x_offset),
                     ..default()
                 },
@@ -83,7 +83,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut state: ResM
             background_color: Color::NONE.into(),
             style: Style {
                 position_type: PositionType::Absolute,
-                bottom: Val::Px(0.0),
+                bottom: Val::ZERO,
                 ..default()
             },
             ..default()

--- a/examples/ui/overflow_debug.rs
+++ b/examples/ui/overflow_debug.rs
@@ -101,7 +101,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 })
                 .with_children(|parent| {
                     parent.spawn(TextBundle::from_section(
-                        vec![
+                        [
                             "Toggle Overflow (O)",
                             "Next Container Size (S)",
                             "Toggle Animation (space)",

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -19,11 +19,11 @@ bitflags! {
 
 const CLIPPY_FLAGS: [&str; 8] = [
     "-Aclippy::type_complexity",
+    "-Aclippy::explicit_iter_loop",
     "-Wclippy::doc_markdown",
     "-Wclippy::redundant_else",
     "-Wclippy::match_same_arms",
     "-Wclippy::semicolon_if_nothing_returned",
-    "-Wclippy::explicit_iter_loop",
     "-Wclippy::map_flatten",
     "-Dwarnings",
 ];


### PR DESCRIPTION
# Objective

- Move schedule name into `Schedule` to allow the schedule name to be used for errors and tracing in Schedule methods
- Fixes #9510

## Solution

- Move label onto `Schedule` and adjust api's on `World` and `Schedule` to not pass explicit label where it makes sense to.
- add name to errors and tracing.
- `Schedule::new` now takes a label so either add the label or use `Schedule::default` which uses a default label. `default` is mostly used in doc examples and tests.

---

## Changelog

- move label onto `Schedule` to improve error message and logging for schedules.

## Migration Guide

`Schedule::new` and `App::add_schedule`
```rust
// old
let schedule = Schedule::new();
app.add_schedule(MyLabel, schedule);

// new
let schedule = Schedule::new(MyLabel);
app.add_schedule(schedule);
```

if you aren't using a label and are using the schedule struct directly you can use the default constructor.
```rust
// old
let schedule = Schedule::new();
schedule.run(world);

// new
let schedule = Schedule::default();
schedule.run(world);
```

`Schedules:insert`
```rust
// old
let schedule = Schedule::new();
schedules.insert(MyLabel, schedule);

// new
let schedule = Schedule::new(MyLabel);
schedules.insert(schedule);
```

`World::add_schedule`
```rust
// old
let schedule = Schedule::new();
world.add_schedule(MyLabel, schedule);

// new
let schedule = Schedule::new(MyLabel);
world.add_schedule(schedule);
```
